### PR TITLE
Save layout boxes for layout_controller.php

### DIFF
--- a/admin/includes/languages/english/layout_controller.php
+++ b/admin/includes/languages/english/layout_controller.php
@@ -1,26 +1,13 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                                 |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: layout_controller.php 3197 2006-03-17 21:40:58Z drbyte $
-//
+/**
+ * @package admin
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: layout_controller.php 2014-07-28 drbyte $
+ */
 
-define('HEADING_TITLE', 'Column Boxes');
+define('HEADING_TITLE', 'Column Boxes for template: ');
 
 define('TABLE_HEADING_LAYOUT_BOX_NAME', 'Box File Name');
 define('TABLE_HEADING_LAYOUT_BOX_STATUS', 'LEFT/RIGHT COLUMN<br />Status');
@@ -36,7 +23,6 @@ define('TEXT_INFO_LAYOUT_BOX_NAME', 'Box Name:');
 define('TEXT_INFO_LAYOUT_BOX_LOCATION','Location: (Single Column ignores this setting)');
 define('TEXT_INFO_LAYOUT_BOX_STATUS', 'Left/Right Column Status: ');
 define('TEXT_INFO_LAYOUT_BOX_STATUS_SINGLE', 'Single Column Status: ');
-define('TEXT_INFO_LAYOUT_BOX_STATUS_INFO','ON= 1 OFF=0');
 define('TEXT_INFO_LAYOUT_BOX_SORT_ORDER', 'Left/Right Column Sort Order:');
 define('TEXT_INFO_LAYOUT_BOX_SORT_ORDER_SINGLE', 'Single Column Sort Order:');
 define('TEXT_INFO_INSERT_INTRO', 'Please enter the new box with its related data');
@@ -45,43 +31,27 @@ define('TEXT_INFO_HEADING_NEW_BOX', 'New Box');
 define('TEXT_INFO_HEADING_EDIT_BOX', 'Edit Box');
 define('TEXT_INFO_HEADING_DELETE_BOX', 'Delete Box');
 define('TEXT_INFO_DELETE_MISSING_LAYOUT_BOX','Delete missing box from Template listing: ');
-define('TEXT_INFO_DELETE_MISSING_LAYOUT_BOX_NOTE','NOTE: This does not remove files and you can re-add the box at anytime by adding it to the correct directory.<br /><br /><strong>Delete box name: </strong>');
-define('TEXT_INFO_RESET_TEMPLATE_SORT_ORDER','Reset All Box Sort Order to match DEFAULT Sort Order for Template: ');
-define('TEXT_INFO_RESET_TEMPLATE_SORT_ORDER_NOTE','This does not remove any of the boxes. It will only reset the current sort order');
+define('TEXT_INFO_DELETE_MISSING_LAYOUT_BOX_NOTE','NOTE: This does not remove files and you can re-add the box at any time by adding it to the correct directory.<br /><br /><strong>Delete box name: </strong>');
+define('TEXT_INFO_RESET_TEMPLATE_SORT_ORDER','Resets all boxes to the last-saved settings. (Typically necessary when installing new templates.)');
+define('TEXT_INFO_RESET_TEMPLATE_SORT_ORDER_NOTE','<em>Any changes made since the last save will be lost.</em>');
 define('TEXT_INFO_BOX_DETAILS','Box Details: ');
+define('TEXT_INFO_SET_AS_DEFAULT','Save the above settings as the default.');
+define('TEXT_INFO_THE_ABOVE_SETTINGS_ARE_FOR', ' (eg: this will copy the settings for the [<strong>%s</strong>] template to be the new defaults)');
 
-////////////////
-
-define('HEADING_TITLE_LAYOUT_TEMPLATE', 'Site Template Layout');
-
-define('TABLE_HEADING_LAYOUT_TITLE', 'Title');
-define('TABLE_HEADING_LAYOUT_VALUE', 'Value');
 define('TABLE_HEADING_ACTION', 'Action');
 
 define('TABLE_HEADING_BOXES_PATH', 'Boxes Path: ');
 define('TEXT_WARNING_NEW_BOXES_FOUND', 'WARNING: New boxes found: ');
-
-define('TEXT_MODULE_DIRECTORY', 'Site Layout Directory:');
-define('TEXT_INFO_DATE_ADDED', 'Date Added:');
-define('TEXT_INFO_LAST_MODIFIED', 'Last Modified:');
-
-// layout box text in includes/boxes/layout.php
-define('BOX_HEADING_LAYOUT', 'Layout');
-define('BOX_LAYOUT_COLUMNS', 'Column Controller');
-
-// file exists
 define('TEXT_GOOD_BOX',' ');
-define('TEXT_BAD_BOX','<font color="ff0000"><b>MISSING</b></font><br />');
+define('TEXT_BAD_BOX','<span class="alert">MISSING</span><br />');
 
-
-// Success message
-define('SUCCESS_BOX_DELETED','Successfully removed from the template of the box: ');
-define('SUCCESS_BOX_RESET','Successfully Reset all box settings to the Default settings for Template: ');
-define('SUCCESS_BOX_UPDATED','Successfully Updated settings for box: ');
+// Success messages
+define('SUCCESS_BOX_DELETED','Update: Removed sidebox from template ');
+define('SUCCESS_BOX_RESET','Update: All sideboxes reset for template ');
+define('SUCCESS_BOX_UPDATED','Update: updated settings for sidebox ');
+define('SUCCESS_BOX_SET_DEFAULTS','Update: Updated Default settings for template ');
 
 define('TEXT_ON',' ON ');
 define('TEXT_OFF',' OFF ');
 define('TEXT_LEFT',' LEFT ');
 define('TEXT_RIGHT',' RIGHT ');
-
-?>

--- a/admin/includes/template/css/normalize.css
+++ b/admin/includes/template/css/normalize.css
@@ -419,5 +419,5 @@ table {
 
 td,
 th {
-  padding: 0;
+  padding: 0; vertical-align: top;
 }

--- a/admin/layout_controller.php
+++ b/admin/layout_controller.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: layout_controller.php 19294 2011-07-28 18:15:46Z drbyte $
+ * @version $Id: layout_controller.php 2014-07-28 drbyte $
  */
 
   require('includes/application_top.php');
@@ -127,11 +127,26 @@
         $messageStack->add_session(SUCCESS_BOX_RESET . $template_dir, 'success');
         zen_redirect(zen_href_link(FILENAME_LAYOUT_CONTROLLER, 'page=' . $_GET['page']));
         break;
+      case 'save_defaults':
+        $db->Execute(" update " . TABLE_LAYOUT_BOXES . " def, " . TABLE_LAYOUT_BOXES . " curr set
+                         def.layout_box_status = curr.layout_box_status,
+                         def.layout_box_location = curr.layout_box_location,
+                         def.layout_box_sort_order = curr.layout_box_sort_order,
+                         def.layout_box_sort_order_single = curr.layout_box_sort_order_single,
+                         def.layout_box_status_single = curr.layout_box_status_single
+                       where def.layout_template   = 'default_template_settings'
+                       and curr.layout_template = '" . zen_db_input($template_dir) . "'
+                       and def.layout_box_name = curr.layout_box_name");
+
+        $messageStack->add_session(SUCCESS_BOX_SET_DEFAULTS . '<strong>' . $template_dir . '</strong>', 'success');
+        zen_redirect(zen_href_link(FILENAME_LAYOUT_CONTROLLER, 'page=' . $_GET['page']));
+        break;
     }
   }
 
 require('includes/admin_html_head.php');
 ?>
+
 </head>
 <body>
 <!-- header //-->
@@ -139,7 +154,7 @@ require('includes/admin_html_head.php');
 <!-- header_eof //-->
 
 <!-- body //-->
-<table border="0" width="100%" cellspacing="2" cellpadding="2">
+<table border="0" width="100%" cellspacing="2" cellpadding="2" id="layoutController" class="mainAdmin">
   <tr>
 <!-- body_text //-->
     <td width="100%" valign="top"><table border="0" width="100%" cellspacing="0" cellpadding="2">
@@ -217,7 +232,7 @@ if ($warning_new_box) {
     if (($column_controller->fields['layout_box_location'] != $last_box_column) and !$column_controller->EOF) {
 ?>
               <tr valign="top">
-                <td colspan="7" height="20" align="center" valign="middle"><?php echo zen_draw_separator('pixel_black.gif', '90%', '3'); ?></td>
+                <td colspan="8" height="20" align="center" valign="middle"><?php echo zen_draw_separator('pixel_black.gif', '90%', '3'); ?></td>
               </tr>
 <?php
     }
@@ -327,21 +342,22 @@ if ($warning_new_box) {
   }
 ?>
   </tr>
+
+
   <tr>
-    <td><table align="center">
+    <td align="center"><table width="500">
       <tr>
-        <td class="main" align="left">
-          <?php echo '<br />' . TEXT_INFO_RESET_TEMPLATE_SORT_ORDER . '<strong>' . $template_dir . '</strong>'; ?>
-        </td>
-      </tr>
-      <tr>
-        <td class="main" align="center">
+        <td>
+          <?php echo '<a href="' . zen_href_link(FILENAME_LAYOUT_CONTROLLER, 'page=' . $_GET['page'] . '&cID=' . $bInfo->layout_id . '&action=reset_defaults') . '">' . zen_image_button('button_reset.gif', IMAGE_RESET) . '</a>'; ?>
+          <br>
+          <?php echo TEXT_INFO_RESET_TEMPLATE_SORT_ORDER; ?>
+          <br>
           <?php echo TEXT_INFO_RESET_TEMPLATE_SORT_ORDER_NOTE; ?>
         </td>
-      </tr>
-      <tr>
-        <td class="main" align="center">
-          <?php echo '<br /><a href="' . zen_href_link(FILENAME_LAYOUT_CONTROLLER, 'page=' . $_GET['page'] . '&cID=' . $bInfo->layout_id . '&action=reset_defaults') . '">' . zen_image_button('button_reset.gif', IMAGE_RESET) . '</a>'; ?>
+        <td style="padding-left: 20px">
+          <?php echo '<a href="' . zen_href_link(FILENAME_LAYOUT_CONTROLLER, 'page=' . $_GET['page'] . '&cID=' . $bInfo->layout_id . '&action=save_defaults') . '">' . zen_image_button('button_save.gif', IMAGE_SAVE) . '</a>'; ?>
+          <br>
+          <?php echo TEXT_INFO_SET_AS_DEFAULT . sprintf(TEXT_INFO_THE_ABOVE_SETTINGS_ARE_FOR, $template_dir); ?>
         </td>
       </tr>
     </table></td>


### PR DESCRIPTION
Integrating save layout boxes with a change to normalize.css to default table cell vertical alignment to top. Also,  added divs to table for more control over admin css.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/121)
<!-- Reviewable:end -->
