### PR TITLE
MySQL GROUP BY clauses should list all SELECTed columns

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -609,7 +609,7 @@ function zen_get_profiles($withUsers = FALSE)
     $sql = "SELECT p.profile_id, p.profile_name, COUNT(a.admin_profile) as profile_users
             FROM " . TABLE_ADMIN_PROFILES . " p
             LEFT JOIN " . TABLE_ADMIN . " a ON a.admin_profile = p.profile_id
-            GROUP BY p.profile_id";
+            GROUP BY p.profile_id, p.profile_name";
     $result = $db->Execute($sql);
     while (!$result->EOF)
     {

--- a/admin/stats_customers.php
+++ b/admin/stats_customers.php
@@ -43,7 +43,12 @@ require('includes/admin_html_head.php');
               </tr>
 <?php
   if (isset($_GET['page']) && ($_GET['page'] > 1)) $rows = $_GET['page'] * MAX_DISPLAY_SEARCH_RESULTS_REPORTS - MAX_DISPLAY_SEARCH_RESULTS_REPORTS;
-  $customers_query_raw = "select c.customers_id, c.customers_firstname, c.customers_lastname, sum(op.products_quantity * op.final_price)+sum(op.onetime_charges)  as ordersum from " . TABLE_CUSTOMERS . " c, " . TABLE_ORDERS_PRODUCTS . " op, " . TABLE_ORDERS . " o where c.customers_id = o.customers_id and o.orders_id = op.orders_id group by c.customers_id, c.customers_firstname, c.customers_lastname order by ordersum DESC";
+  $customers_query_raw = "SELECT c.customers_id, c.customers_firstname, c.customers_lastname, sum(op.products_quantity * op.final_price)+sum(op.onetime_charges)  as ordersum
+                          FROM " . TABLE_CUSTOMERS . " c, " . TABLE_ORDERS_PRODUCTS . " op, " . TABLE_ORDERS . " o
+                          WHERE c.customers_id = o.customers_id
+                          AND o.orders_id = op.orders_id
+                          GROUP BY c.customers_id, c.customers_firstname, c.customers_lastname
+                          ORDER BY ordersum DESC";
   $customers_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_REPORTS, $customers_query_raw, $customers_query_numrows);
 // fix counted customers
   $customers_query_m = $db->Execute("select customers_id

--- a/admin/stats_customers.php
+++ b/admin/stats_customers.php
@@ -43,7 +43,7 @@ require('includes/admin_html_head.php');
               </tr>
 <?php
   if (isset($_GET['page']) && ($_GET['page'] > 1)) $rows = $_GET['page'] * MAX_DISPLAY_SEARCH_RESULTS_REPORTS - MAX_DISPLAY_SEARCH_RESULTS_REPORTS;
-  $customers_query_raw = "select c.customers_id, c.customers_firstname, c.customers_lastname, sum(op.products_quantity * op.final_price)+sum(op.onetime_charges)  as ordersum from " . TABLE_CUSTOMERS . " c, " . TABLE_ORDERS_PRODUCTS . " op, " . TABLE_ORDERS . " o where c.customers_id = o.customers_id and o.orders_id = op.orders_id group by c.customers_id order by ordersum DESC";
+  $customers_query_raw = "select c.customers_id, c.customers_firstname, c.customers_lastname, sum(op.products_quantity * op.final_price)+sum(op.onetime_charges)  as ordersum from " . TABLE_CUSTOMERS . " c, " . TABLE_ORDERS_PRODUCTS . " op, " . TABLE_ORDERS . " o where c.customers_id = o.customers_id and o.orders_id = op.orders_id group by c.customers_id, c.customers_firstname, c.customers_lastname order by ordersum DESC";
   $customers_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_REPORTS, $customers_query_raw, $customers_query_numrows);
 // fix counted customers
   $customers_query_m = $db->Execute("select customers_id

--- a/admin/stats_products_purchased.php
+++ b/admin/stats_products_purchased.php
@@ -168,18 +168,24 @@ if ($products_filter > 0 or $products_filter_name_model != '') {
   if (isset($_GET['page']) && ($_GET['page'] > 1)) $rows = $_GET['page'] * MAX_DISPLAY_SEARCH_RESULTS_REPORTS - MAX_DISPLAY_SEARCH_RESULTS_REPORTS;
 // The following OLD query only considers the "products_ordered" value from the products table.
 // Thus this older query is somewhat deprecated
-  $products_query_raw = "select p.products_id, p.products_ordered, pd.products_name from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd where pd.products_id = p.products_id and pd.language_id = '" . $_SESSION['languages_id']. "' and p.products_ordered > 0 group by pd.products_id, pd.products_name order by p.products_ordered DESC, pd.products_name";
+  $products_query_raw = "SELECT p.products_id, p.products_ordered, pd.products_name
+                         FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                         WHERE pd.products_id = p.products_id
+                         AND pd.language_id = '" . $_SESSION['languages_id']. "'
+                         AND p.products_ordered > 0
+                         GROUP BY pd.products_id, pd.products_name
+                         ORDER BY p.products_ordered DESC, pd.products_name";
 
 // The new query uses real order info from the orders_products table, and is theoretically more accurate.
 // To use this newer query, remove the "1" from the following line ($products_query_raw1 becomes $products_query_raw )
     $products_query_raw1 =
-      "select sum(op.products_quantity) as products_ordered, pd.products_name, op.products_id
-      from ".TABLE_ORDERS_PRODUCTS." op
-      left join " . TABLE_PRODUCTS_DESCRIPTION . " pd
-        on (pd.products_id = op.products_id )
-      where pd.language_id = '" . $_SESSION['languages_id']. "'
-      group by pd.products_id, pd.products_name
-      order by products_ordered DESC, products_name";
+      "SELECT sum(op.products_quantity) as products_ordered, pd.products_name, op.products_id
+       FROM ".TABLE_ORDERS_PRODUCTS." op
+       LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd
+        ON (pd.products_id = op.products_id )
+       WHERE pd.language_id = '" . $_SESSION['languages_id']. "'
+       GROUP BY pd.products_id, pd.products_name
+       ORDER BY products_ordered DESC, products_name";
 
   $products_query_numrows='';
   $products_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_REPORTS, $products_query_raw, $products_query_numrows);

--- a/admin/stats_products_purchased.php
+++ b/admin/stats_products_purchased.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: stats_products_purchased.php 18698 2011-05-04 14:50:06Z wilt $
@@ -168,7 +168,7 @@ if ($products_filter > 0 or $products_filter_name_model != '') {
   if (isset($_GET['page']) && ($_GET['page'] > 1)) $rows = $_GET['page'] * MAX_DISPLAY_SEARCH_RESULTS_REPORTS - MAX_DISPLAY_SEARCH_RESULTS_REPORTS;
 // The following OLD query only considers the "products_ordered" value from the products table.
 // Thus this older query is somewhat deprecated
-  $products_query_raw = "select p.products_id, p.products_ordered, pd.products_name from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd where pd.products_id = p.products_id and pd.language_id = '" . $_SESSION['languages_id']. "' and p.products_ordered > 0 group by pd.products_id order by p.products_ordered DESC, pd.products_name";
+  $products_query_raw = "select p.products_id, p.products_ordered, pd.products_name from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd where pd.products_id = p.products_id and pd.language_id = '" . $_SESSION['languages_id']. "' and p.products_ordered > 0 group by pd.products_id, pd.products_name order by p.products_ordered DESC, pd.products_name";
 
 // The new query uses real order info from the orders_products table, and is theoretically more accurate.
 // To use this newer query, remove the "1" from the following line ($products_query_raw1 becomes $products_query_raw )
@@ -178,7 +178,7 @@ if ($products_filter > 0 or $products_filter_name_model != '') {
       left join " . TABLE_PRODUCTS_DESCRIPTION . " pd
         on (pd.products_id = op.products_id )
       where pd.language_id = '" . $_SESSION['languages_id']. "'
-      group by pd.products_id
+      group by pd.products_id, pd.products_name
       order by products_ordered DESC, products_name";
 
   $products_query_numrows='';

--- a/includes/classes/db/mysql/define_queries.php
+++ b/includes/classes/db/mysql/define_queries.php
@@ -5,7 +5,7 @@
  * can be used to assist with special requirements for other database-abstraction configurations
  *
  * @package classes
- * @copyright Copyright 2003-2005 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: define_queries.php 4587 2006-09-23 00:46:06Z ajeh $
  */
@@ -29,8 +29,7 @@ DEFINE('SQL_ALSO_PURCHASED', "select p.products_id, p.products_image
                      and opb.products_id = p.products_id
                      and opb.orders_id = o.orders_id
                      and p.products_status = 1
-                     group by p.products_id
+                     group by p.products_id, p.products_image
                      order by o.date_purchased desc
                      limit " . MAX_DISPLAY_ALSO_PURCHASED);
 DEFINE('SQL_SHOW_SHOPPING_CART_EMPTY',"select configuration_key, configuration_value from " . TABLE_CONFIGURATION . " where configuration_key RLIKE 'SHOW_SHOPPING_CART_EMPTY' and configuration_value > 0 order by configuration_value");
-?>

--- a/includes/classes/db/mysql/define_queries.php
+++ b/includes/classes/db/mysql/define_queries.php
@@ -20,16 +20,16 @@ DEFINE('SQL_SHOW_PRODUCT_INFO_LISTING_BELOW',"select configuration_key, configur
 DEFINE('SQL_BANNER_CHECK_QUERY', "select count(*) as count from " . TABLE_BANNERS_HISTORY . "                where banners_id = '%s' and date_format(banners_history_date, '%%Y%%m%%d') = date_format(now(), '%%Y%%m%%d')");
 DEFINE('SQL_BANNER_CHECK_UPDATE', "update " . TABLE_BANNERS_HISTORY . " set banners_shown = banners_shown +1 where banners_id = '%s' and date_format(banners_history_date, '%%Y%%m%%d') = date_format(now(), '%%Y%%m%%d')");
 DEFINE('SQL_BANNER_UPDATE_CLICK_COUNT', "update " . TABLE_BANNERS_HISTORY . " set banners_clicked = banners_clicked + 1 where banners_id = '%s' and date_format(banners_history_date, '%%Y%%m%%d') = date_format(now(), '%%Y%%m%%d')");
-DEFINE('SQL_ALSO_PURCHASED', "select p.products_id, p.products_image
-                     from " . TABLE_ORDERS_PRODUCTS . " opa, " . TABLE_ORDERS_PRODUCTS . " opb, "
+DEFINE('SQL_ALSO_PURCHASED', "SELECT p.products_id, p.products_image
+                     FROM " . TABLE_ORDERS_PRODUCTS . " opa, " . TABLE_ORDERS_PRODUCTS . " opb, "
                             . TABLE_ORDERS . " o, " . TABLE_PRODUCTS . " p
-                     where opa.products_id = '%s'
-                     and opa.orders_id = opb.orders_id
-                     and opb.products_id != '%s'
-                     and opb.products_id = p.products_id
-                     and opb.orders_id = o.orders_id
-                     and p.products_status = 1
-                     group by p.products_id, p.products_image
-                     order by o.date_purchased desc
-                     limit " . MAX_DISPLAY_ALSO_PURCHASED);
+                     WHERE opa.products_id = '%s'
+                     AND opa.orders_id = opb.orders_id
+                     AND opb.products_id != '%s'
+                     AND opb.products_id = p.products_id
+                     AND opb.orders_id = o.orders_id
+                     AND p.products_status = 1
+                     GROUP BY p.products_id, p.products_image
+                     ORDER BY o.date_purchased desc
+                     LIMIT " . MAX_DISPLAY_ALSO_PURCHASED);
 DEFINE('SQL_SHOW_SHOPPING_CART_EMPTY',"select configuration_key, configuration_value from " . TABLE_CONFIGURATION . " where configuration_key RLIKE 'SHOW_SHOPPING_CART_EMPTY' and configuration_value > 0 order by configuration_value");


### PR DESCRIPTION
Not including all SELECTed fields can result in ambiguous GROUP BY results, and is non-standard SQL

Ref: https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/251)
<!-- Reviewable:end -->
