### PR TITLE
Replace shell_exec('hostname') with gethostname()

### DIFF
--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: header.php 19529 2011-09-19 13:11:40Z wilt $
@@ -72,7 +72,7 @@ if ($messageStack->size > 0) {
     echo '&nbsp;' . date("O" , time()) . ' GMT';  // time zone
     echo '&nbsp;[' . $_SERVER['REMOTE_ADDR'] . ']'; // current admin user's IP address
     echo '<br />';
-    echo @shell_exec('hostname'); //what server am I working on?
+    echo @gethostname(); //what server am I working on?
     echo ' - ' . date_default_timezone_get(); //what is the PHP timezone set to?
     $loc = setlocale(LC_TIME, 0);
     if ($loc !== FALSE) echo ' - ' . $loc; //what is the locale in use?

--- a/admin/includes/template/common/tplHeader.php
+++ b/admin/includes/template/common/tplHeader.php
@@ -72,7 +72,7 @@ if ($tplVars['messageStack']->size > 0) {
     echo '&nbsp;' . date("O" , time()) . ' GMT';  // time zone
     echo '&nbsp;[' . $_SERVER['REMOTE_ADDR'] . ']'; // current admin user's IP address
     echo '<br />';
-    echo @shell_exec('hostname'); //what server am I working on?
+    echo @gethostname(); //what server am I working on?
     echo ' - ' . date_default_timezone_get(); //what is the PHP timezone set to?
     $loc = setlocale(LC_TIME, 0);
     if ($loc !== FALSE) echo ' - ' . $loc; //what is the locale in use?


### PR DESCRIPTION
Some hosts have disabled shell_exec() for security reasons. Using gethostname() avoids that limitation, giving same results.

Props: @lat9 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/254)
<!-- Reviewable:end -->
