### PR TITLE
Correct GV redeem issues with spaces

### DIFF
--- a/includes/modules/pages/gv_redeem/header_php.php
+++ b/includes/modules/pages/gv_redeem/header_php.php
@@ -3,7 +3,7 @@
  * GV redeem
  *
  * @package page
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: header_php.php 6736 2007-08-19 09:55:01Z drbyte $
@@ -11,6 +11,8 @@
  */
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+$_GET['gv_no'] = zen_sanitize_string(trim($_GET['gv_no']));
+
 // if the customer is not logged on, redirect them to the login page
 if (!$_SESSION['customer_id']) {
   $_SESSION['navigation']->set_snapshot();


### PR DESCRIPTION
Correct redeem issues with spaces often caused by copy/paste or customer error in entering redemption codes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/257)
<!-- Reviewable:end -->
