### PR TITLE
MySQL strict mode requires no default value on mediumtext fields

### DIFF
--- a/admin/includes/classes/class.admin.zcObserverLogWriterDatabase.php
+++ b/admin/includes/classes/class.admin.zcObserverLogWriterDatabase.php
@@ -95,7 +95,7 @@ class zcObserverLogWriterDatabase extends base {
     }
     if (!$found_logmessage)
     {
-      $sql = "ALTER TABLE " . TABLE_ADMIN_ACTIVITY_LOG . " ADD COLUMN logmessage mediumtext NOT NULL default ''";
+      $sql = "ALTER TABLE " . TABLE_ADMIN_ACTIVITY_LOG . " ADD COLUMN logmessage mediumtext NOT NULL";
       $db->Execute($sql);
     }
     // add 'severity' field of type varchar(9)

--- a/testFramework/dbtests/DbLoggingTest.php
+++ b/testFramework/dbtests/DbLoggingTest.php
@@ -83,7 +83,7 @@ class testDbLogging extends zcAdminTestCase
         flagged tinyint NOT NULL default '0',
         attention varchar(255) NOT NULL default '',
         gzpost mediumblob,
-        logmessage mediumtext NOT NULL default '',
+        logmessage mediumtext NOT NULL,
         severity varchar(9) NOT NULL default 'info',
         PRIMARY KEY  (log_id),
         KEY idx_page_accessed_zen (page_accessed),

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -124,7 +124,7 @@ CREATE TABLE admin_activity_log (
   flagged tinyint NOT NULL default '0',
   attention varchar(255) NOT NULL default '',
   gzpost mediumblob,
-  logmessage mediumtext NOT NULL default '',
+  logmessage mediumtext NOT NULL,
   severity varchar(9) NOT NULL default 'info',
   PRIMARY KEY  (log_id),
   KEY idx_page_accessed_zen (page_accessed),


### PR DESCRIPTION
Ref: http://www.zen-cart.com/showthread.php?215713-fatal-error-1101

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/260)
<!-- Reviewable:end -->
