### PR TITLE
Add DB_MYSQL_MODE override capability to set MySQL sql_mode for the session

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -4,7 +4,7 @@
  * Class used for database abstraction to MySQL via mysqli
  *
  * @package classes
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @copyright Portions adapted from http://www.data-diggers.com/
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -77,6 +77,9 @@ class queryFactory extends base {
         $this->db_connected = true;
         if (!defined('DISABLE_MYSQL_TZ_SET')) {
           mysqli_query($this->link, "SET time_zone = '" . substr_replace(date("O"),":",-2,0) . "'");
+        }
+        if (defined('DB_MYSQL_MODE') && DB_MYSQL_MODE != '') {
+          mysqli_query($this->link, "SET SESSION sql_mode = '" . $this->prepare_input(DB_MYSQL_MODE) . "'");
         }
         return true;
       } else {


### PR DESCRIPTION
Add DB_MYSQL_MODE override capability to set MySQL sql_mode for the session

To enable, simply add a define to configure.php:
`define('DB_MYSQL_MODE', 'TRADITIONAL');`

Ref: https://dev.mysql.com/doc/refman/5.6/en/sql-mode.html

Multiple modes can be combined by separating with a comma, for example:
`define('DB_MYSQL_MODE', 'NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY');`

credit to @lhungil for the suggestion

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/263)
<!-- Reviewable:end -->
