### PR TITLE
Fix authnet AIM field type for MySQL strict mode

### DIFF
--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -731,7 +731,7 @@ class authorizenet_aim extends base {
       $sql = $db->bindVars($sql, ':respCode', $response[0], 'integer');
       $sql = $db->bindVars($sql, ':respText', $db_response_text, 'string');
       $sql = $db->bindVars($sql, ':authType', $response[11], 'string');
-      $sql = $db->bindVars($sql, ':transID', $this->transaction_id, 'string');
+      $sql = $db->bindVars($sql, ':transID', $this->transaction_id, 'integer');
       $sql = $db->bindVars($sql, ':sentData', print_r($this->reportable_submit_data, true), 'string');
       $sql = $db->bindVars($sql, ':recvData', print_r($response, true), 'string');
       $sql = $db->bindVars($sql, ':orderTime', $order_time, 'string');


### PR DESCRIPTION
Fix authnet AIM field type in bindVar query preparation

Can't send a `string` to an `integer` field when MySQL is in `strict` mode.