### PR TITLE
Update sessions.php to allow session_id to contain comma and dash

### DIFF
--- a/includes/functions/sessions.php
+++ b/includes/functions/sessions.php
@@ -100,7 +100,7 @@ if (!defined('IS_ADMIN_FLAG')) {
     } elseif (defined('SESSION_TIMEOUT_CATALOG') && (int)SESSION_TIMEOUT_CATALOG > 120) {
       @ini_set('session.gc_maxlifetime', (int)SESSION_TIMEOUT_CATALOG);
     }
-    if (preg_replace('/[a-zA-Z0-9]/', '', session_id()) != '')
+    if (preg_replace('/[a-zA-Z0-9,-]/', '', session_id()) != '')
     {
       zen_session_id(md5(uniqid(rand(), true)));
     }
@@ -114,7 +114,7 @@ if (!defined('IS_ADMIN_FLAG')) {
   function zen_session_id($sessid = '') {
     if (!empty($sessid)) {
       $tempSessid = $sessid;
-      if (preg_replace('/[a-zA-Z0-9]/', '', $tempSessid) != '')
+      if (preg_replace('/[a-zA-Z0-9,-]/', '', $tempSessid) != '')
       {
         $sessid = md5(uniqid(rand(), true));
       }
@@ -127,7 +127,7 @@ if (!defined('IS_ADMIN_FLAG')) {
   function zen_session_name($name = '') {
     if (!empty($name)) {
       $tempName = $name;
-      if (preg_replace('/[a-zA-Z0-9]/', '', $tempName) == '') return session_name($name);
+      if (preg_replace('/[a-zA-Z0-9,-]/', '', $tempName) == '') return session_name($name);
       return FALSE;
     } else {
       return session_name();


### PR DESCRIPTION
Update preg_replace regex to include commas and minus signs for session_id

Ref: http://www.zen-cart.com/showthread.php?215961-Timeout-during-final-step-of-checkout-Solution