### PR TITLE
Fix detection of whether "cheapest shipping selector" should be triggered

### DIFF
--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -212,8 +212,7 @@ if (isset($_SESSION['cart']->cartID)) {
 // if the modules status was changed when none were available, to save on implementing
 // a javascript force-selection method, also automatically select the cheapest shipping
 // method if more than one module is now enabled
-  if ( !isset($_SESSION['shipping']) && (zen_count_shipping_modules() > 1) )  $_SESSION['shipping'] = $shipping_modules->cheapest();
-
+  if ((!isset($_SESSION['shipping']) || !isset($_SESSION['shipping']['id']) || $_SESSION['shipping']['id'] == '') && zen_count_shipping_modules() > 1)  $_SESSION['shipping'] = $shipping_modules->cheapest();
 
   // Should address-edit button be offered?
   $displayAddressEdit = (MAX_ADDRESS_BOOK_ENTRIES >= 2);

--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -208,11 +208,11 @@ if (isset($_SESSION['cart']->cartID)) {
     }
   }
 
-// if no shipping method has been selected, automatically select the cheapest method.
-// if the modules status was changed when none were available, to save on implementing
+// If no shipping method has been selected, automatically select the cheapest method.
+// If the module's status was changed when none were available, to save on implementing
 // a javascript force-selection method, also automatically select the cheapest shipping
 // method if more than one module is now enabled
-  if ((!isset($_SESSION['shipping']) || !isset($_SESSION['shipping']['id']) || $_SESSION['shipping']['id'] == '') && zen_count_shipping_modules() > 1)  $_SESSION['shipping'] = $shipping_modules->cheapest();
+  if ((!isset($_SESSION['shipping']) || (!isset($_SESSION['shipping']['id']) || $_SESSION['shipping']['id'] == '') && zen_count_shipping_modules() >= 1)) $_SESSION['shipping'] = $shipping_modules->cheapest();
 
   // Should address-edit button be offered?
   $displayAddressEdit = (MAX_ADDRESS_BOOK_ENTRIES >= 2);


### PR DESCRIPTION
Fix detection of whether "cheapest shipping selector" should be triggered

Detection should be based on the 'id' element, not the 'shipping' element alone.

Without this fix the cheapest shipping calculation will never run. Was broken in v1.5.3 and v1.5.4.