### PR TITLE
Add "hostname" override for email generator.

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -334,6 +334,10 @@
       @ini_set('mail.add_x_header', 0);
 
       $ErrorInfo = '';
+
+      // set Hostname, since it can aid in delivery of emails. If emails are being rejected, comment out the following line and try again:
+      $mail->Hostname = defined('EMAIL_HOSTNAME') ? EMAIL_HOSTNAME : preg_replace('~(^https?://|\/.*$)~', '', defined('HTTP_CATALOG_SERVER') ? HTTP_CATALOG_SERVER : HTTP_SERVER);
+
       $zco_notifier->notify('NOTIFY_EMAIL_READY_TO_SEND', array($mail), $mail);
       /**
        * Send the email. If an error occurs, trap it and display it in the messageStack

--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -335,8 +335,10 @@
 
       $ErrorInfo = '';
 
-      // set Hostname, since it can aid in delivery of emails. If emails are being rejected, comment out the following line and try again:
-      $mail->Hostname = defined('EMAIL_HOSTNAME') ? EMAIL_HOSTNAME : preg_replace('~(^https?://|\/.*$)~', '', defined('HTTP_CATALOG_SERVER') ? HTTP_CATALOG_SERVER : HTTP_SERVER);
+      // set Hostname, since it can aid in delivery of emails.
+      $defaultHostname = preg_replace('~(^https?://|\/.*$)~', '', defined('HTTP_CATALOG_SERVER') ? HTTP_CATALOG_SERVER : HTTP_SERVER);
+      // If emails are being rejected, comment out the following line and try again:
+      $mail->Hostname = defined('EMAIL_HOSTNAME') ? EMAIL_HOSTNAME : $defaultHostname;
 
       $zco_notifier->notify('NOTIFY_EMAIL_READY_TO_SEND', array($mail), $mail);
       /**


### PR DESCRIPTION
Add "hostname" override for email generator.

Although rare, some heavily "shared" servers are configured to handle sub-sub-domains, and the auto-detection of the email hostname isn't always accurate, especially if SERVER_NAME isn't passed correctly to PHP.

This change allows the ability to specify the hostname to use in Message-Id and Received headers and as default HELO string.

To use: define EMAIL_HOSTNAME in the extra_configures or extra_datafiles folder on both catalog and admin sides.