### PR TITLE
Fix call to nonexistent ErrorMsg() method

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -34,7 +34,7 @@ class zcDatabaseInstaller
     $this->dbPrefix = $options['db_prefix'];
     $this->dbCharset = $options['db_charset'];
     $this->dbType = in_array($options['db_type'], $dbtypes) ? $options['db_type'] : 'mysql';
-    $this->debugLevel = isset($options['debug']) ? $options['debug'] : FALSE;
+    $this->dieOnErrors = isset($options['dieOnErrors']) ? (bool)$options['dieOnErrors'] : FALSE;
     $this->errors = array();
     $this->basicParseStrings = array(
     'DROP TABLE IF EXISTS ',
@@ -56,22 +56,13 @@ class zcDatabaseInstaller
 
     );
   }
-  public function getConnection($dieOnErrors = false)
+  public function getConnection()
   {
     require_once(DIR_FS_ROOT . 'includes/classes/db/' . $this->dbType . '/query_factory.php');
     $this->db = new queryFactory;
     $options = array('dbCharset'=>$this->dbCharset);
-    $result = $this->db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', $dieOnErrors, $options);
+    $result = $this->db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', $this->dieOnErrors, $options);
     return $result;
-  }
-  public function getDb($dieOnErrors = false)
-  {
-    require_once(DIR_FS_ROOT . 'includes/classes/db/' . $this->dbType . '/query_factory.php');
-    $db = new queryFactory;
-    $options = array('dbCharset'=>$this->dbCharset);
-    $result = $db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', $dieOnErrors, $options);
-    if ($result) return $db;
-    return false;
   }
   public function parseSqlFile($fileName, $options = NULL)
   {

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -2,9 +2,9 @@
 /**
  * file contains zcDatabaseInstaller Class
  * @package Installer
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id:
+ * @version $Id: New in v1.6.0
  *
  */
 /**
@@ -56,22 +56,22 @@ class zcDatabaseInstaller
 
     );
   }
-  public function getConnection()
+  public function getConnection($dieOnErrors = false)
   {
     require_once(DIR_FS_ROOT . 'includes/classes/db/' . $this->dbType . '/query_factory.php');
     $this->db = new queryFactory;
     $options = array('dbCharset'=>$this->dbCharset);
-    $result = $this->db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', FALSE, $options);
+    $result = $this->db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', $dieOnErrors, $options);
     return $result;
   }
-  public function getDb()
+  public function getDb($dieOnErrors = false)
   {
     require_once(DIR_FS_ROOT . 'includes/classes/db/' . $this->dbType . '/query_factory.php');
     $db = new queryFactory;
     $options = array('dbCharset'=>$this->dbCharset);
-    $result = $db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', FALSE, $options);
+    $result = $db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', $dieOnErrors, $options);
     if ($result) return $db;
-    return FALSE;
+    return false;
   }
   public function parseSqlFile($fileName, $options = NULL)
   {
@@ -403,14 +403,15 @@ class zcDatabaseInstaller
     global $request_type;
     if ($request_type == 'SSL') {
       $sql = "UPDATE " . $this->dbPrefix . "configuration set configuration_value = '1:1', last_modified = now() where configuration_key = 'SSLPWSTATUSCHECK'";
-      $this->db->Execute($sql) or die("Error in query: $sql".$this->db->ErrorMsg());
+      $this->db->Execute($sql);
     }
     $sql = "update " . $this->dbPrefix . "admin set admin_name = '" . $options['admin_user'] . "', admin_email = '" . $options['admin_email'] . "', admin_pass = '" . zen_encrypt_password($options['admin_password']) . "', pwd_last_change_date = " . ($request_type == 'SSL' ? 'NOW()' : '0') . ($request_type == 'SSL' ? '' : ", reset_token = '" . (time() + (72 * 60 * 60)) . "}" . zen_encrypt_password($options['admin_password']) . "'") . " where admin_id = 1";
-    $this->db->Execute($sql) or die("Error in query: $sql".$this->db->ErrorMsg());
+    $this->db->Execute($sql);
 
+// @TODO temporarily disabled
 // enable/disable automatic version-checking
 //    $sql = "update " . $this->dbPrefix . "configuration set configuration_value = '".($this->configInfo['check_for_updates'] ? 'true' : 'false' ) ."' where configuration_key = 'SHOW_VERSION_UPDATE_IN_HEADER'";
-//    $this->db->Execute($sql) or die("Error in query: $sql".$this->db->ErrorMsg());
+//    $this->db->Execute($sql);
   }
   private function camelize($parseString)
   {

--- a/zc_install/includes/modules/pages/completion/header_php.php
+++ b/zc_install/includes/modules/pages/completion/header_php.php
@@ -35,7 +35,7 @@
     $options = $_POST;
     $options['dieOnErrors'] = true;
     $dbInstaller = new zcDatabaseInstaller($options);
-    $result = $dbInstaller->getConnection(true);
+    $result = $dbInstaller->getConnection();
     $extendedOptions = array();
     $error = $dbInstaller->doCompletion($options);
   }

--- a/zc_install/includes/modules/pages/completion/header_php.php
+++ b/zc_install/includes/modules/pages/completion/header_php.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id:
+ * @version $Id: New in v1.6.0 $
  */
 
   require (DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
@@ -34,7 +34,7 @@
     $isUpgrade = FALSE;
     $options = $_POST;
     $dbInstaller = new zcDatabaseInstaller($options);
-    $result = $dbInstaller->getConnection();
+    $result = $dbInstaller->getConnection(true);
     $extendedOptions = array();
     $error = $dbInstaller->doCompletion($options);
   }

--- a/zc_install/includes/modules/pages/completion/header_php.php
+++ b/zc_install/includes/modules/pages/completion/header_php.php
@@ -33,6 +33,7 @@
   {
     $isUpgrade = FALSE;
     $options = $_POST;
+    $options['dieOnErrors'] = true;
     $dbInstaller = new zcDatabaseInstaller($options);
     $result = $dbInstaller->getConnection(true);
     $extendedOptions = array();


### PR DESCRIPTION
zc_install has some legacy SQL execution statements that make a call to $this->db->ErrorMsg() which hasn't existed for several years.

This is refactoring to remove those constructs, and to trigger regular logging and error reporting instead.