### PR TITLE
Send 503 header on db error message

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -142,8 +142,10 @@ class queryFactory extends base {
   }
 
   function show_error() {
-    if ($this->error_number == 0 && $this->error_text == DB_ERROR_NOT_CONNECTED && !headers_sent() && file_exists('nddbc.html') ) {
+    if (!headers_sent()) {
       header("HTTP/1.1 503 Service Unavailable");
+    }
+    if ($this->error_number == 0 && $this->error_text == DB_ERROR_NOT_CONNECTED && file_exists('nddbc.html') ) {
       include('nddbc.html');
     }
     echo '<div class="systemError">';


### PR DESCRIPTION
When a database error occurs, we output a generic message, but it still sends a normal 200 response header, which doesn't tell search engines to skip it.

This sends the 503-service-unavailable header to tell SE's to come back later instead of indexing the error message.

(We were already sending the 503 header, but only when also redirecting to nddbc.html when a "not connected" condition was found ... which is too narrow criteria.)