### PR TITLE
Ensure IP address is not blank

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ajeh  Nov 12 2014 Modified in v1.6.0 $
+ * @version GIT: $Id: Modified in v1.6.0 $
  */
 
 ////
@@ -3571,10 +3571,15 @@ function zen_format_date_raw($date, $formatOut = 'mysql', $formatIn = DATE_FORMA
 }
 
 /**
- * Get and sanitize the current IP address, detecting past proxies where possible
- * @return IP address
+ * Determine visitor's IP address, resolving any proxies where possible.
+ *
+ * @return string
  */
 function zen_get_ip_address() {
+  $ip = '';
+  /**
+   * resolve any proxies
+   */
   if (isset($_SERVER)) {
     if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
       $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
@@ -3591,7 +3596,8 @@ function zen_get_ip_address() {
     } else {
       $ip = $_SERVER['REMOTE_ADDR'];
     }
-  } else {
+  }
+  if (trim($ip) == '') {
     if (getenv('HTTP_X_FORWARDED_FOR')) {
       $ip = getenv('HTTP_X_FORWARDED_FOR');
     } elseif (getenv('HTTP_CLIENT_IP')) {
@@ -3601,8 +3607,20 @@ function zen_get_ip_address() {
     }
   }
 
+  /**
+   * sanitize for validity as an IPv4 or IPv6 address
+   */
+  $ip = preg_replace('~[^a-fA-F0-9.:%/]~', '', $ip);
+
+  /**
+   *  if it's still blank, set to a single dot
+   */
+  if (trim($ip) == '') $ip = '.';
+
   return $ip;
 }
+
+
 
 /**
  * Perform an array multisort, based on 1 or 2 columns being passed

--- a/admin/includes/init_includes/init_sessions.php
+++ b/admin/includes/init_includes/init_sessions.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: init_sessions.php 19956 2011-11-07 15:40:25Z wilt $
+ * @version $Id: init_sessions.php  Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -24,10 +24,10 @@ $secureFlag = (substr(HTTP_SERVER, 0, 6) == 'https:') ? TRUE : FALSE;
 session_set_cookie_params(0, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, TRUE);
 
 /**
- * tidy up $_SERVER['REMOTE_ADDR'] before we use it anywhere else
+ * Sanitize the IP address, and resolve any proxies.
  */
 $ipAddressArray = explode(',', zen_get_ip_address());
-$ipAddress = (sizeof($ipAddressArray) > 0) ? $ipAddressArray[0] : '';
+$ipAddress = (sizeof($ipAddressArray) > 0) ? $ipAddressArray[0] : '.';
 $_SERVER['REMOTE_ADDR'] = $ipAddress;
 
 // lets start our session

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -769,8 +769,16 @@ if (!defined('IS_ADMIN_FLAG')) {
     setcookie($name, $value, $expire, $path, $domain, $secure);
   }
 
-////
+  /**
+   * Determine visitor's IP address, resolving any proxies where possible.
+   *
+   * @return string
+   */
   function zen_get_ip_address() {
+    $ip = '';
+    /**
+     * resolve any proxies
+     */
     if (isset($_SERVER)) {
       if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
         $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
@@ -787,7 +795,8 @@ if (!defined('IS_ADMIN_FLAG')) {
       } else {
         $ip = $_SERVER['REMOTE_ADDR'];
       }
-    } else {
+    }
+    if (trim($ip) == '') {
       if (getenv('HTTP_X_FORWARDED_FOR')) {
         $ip = getenv('HTTP_X_FORWARDED_FOR');
       } elseif (getenv('HTTP_CLIENT_IP')) {
@@ -796,6 +805,16 @@ if (!defined('IS_ADMIN_FLAG')) {
         $ip = getenv('REMOTE_ADDR');
       }
     }
+
+    /**
+     * sanitize for validity as an IPv4 or IPv6 address
+     */
+    $ip = preg_replace('~[^a-fA-F0-9.:%/,]~', '', $ip);
+
+    /**
+     *  if it's still blank, set to a single dot
+     */
+    if (trim($ip) == '') $ip = '.';
 
     return $ip;
   }

--- a/includes/init_includes/init_sanitize.php
+++ b/includes/init_includes/init_sanitize.php
@@ -4,10 +4,11 @@
  * see {@link  http://www.zen-cart.com/wiki/index.php/Developers_API_Tutorials#InitSystem wikitutorials} for more details.
  *
  * @package initSystem
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id:
+ * @version GIT: $Id    Modified in v1.6.0 $
+ *
  * @todo move the array process to security class
  */
 if (! defined('IS_ADMIN_FLAG')) {
@@ -43,10 +44,6 @@ if (isset($_SESSION) && count($_SESSION) > 0) {
     unset($GLOBALS [$key]);
   }
 }
-/**
- * sanitize $_SERVER vars
- */
-$_SERVER ['REMOTE_ADDR'] = preg_replace('~[^a-fA-F0-9.:%/]~', '', $_SERVER ['REMOTE_ADDR']);
 
 /**
  * validate products_id for search engines and bookmarks, etc.

--- a/includes/init_includes/init_sessions.php
+++ b/includes/init_includes/init_sessions.php
@@ -4,10 +4,10 @@
  * see {@link  http://www.zen-cart.com/wiki/index.php/Developers_API_Tutorials#InitSystem wikitutorials} for more details.
  *
  * @package initSystem
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id:
+ * @version $Id:  Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -50,11 +50,10 @@ if (zcRequest::hasPost(zen_session_name())) {
   zen_session_id($_GET[zen_session_name()]);
 }
 /**
- * need to tidy up $_SERVER['REMOTE_ADDR'] here before we use it anywhere else
- * one problem we don't address here is if $_SERVER['REMOTE_ADDRESS'] is not set to anything at all
+ * Sanitize the IP address, and resolve any proxies.
  */
 $ipAddressArray = explode(',', zen_get_ip_address());
-$ipAddress = (sizeof($ipAddressArray) > 0) ? $ipAddressArray[0] : '';
+$ipAddress = (sizeof($ipAddressArray) > 0) ? $ipAddressArray[0] : '.';
 $_SERVER['REMOTE_ADDR'] = $ipAddress;
 /**
  * start the session


### PR DESCRIPTION
If all proxy-detections fail to determine the correct IP address, set it to a single dot (.) to denote this fact.

Ref: http://www.zen-cart.com/showthread.php?214518&p=1257981#post1257981

Also moved the sanitization logic into the same function to keep it in context.