### PR TITLE
Refinements to #144 Admin Title Tags which build upon #307

### DIFF
--- a/admin/admin_activity.php
+++ b/admin/admin_activity.php
@@ -3,10 +3,10 @@
  * Admin Activity Log Viewer/Archiver
  *
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Jun 30 2014 Modified in v1.5.4 $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.6.0 $
  *
  * @TODO: prettify so on-screen output is more friendly, perhaps adding pagination support etc (using existing "s" and "p" params)
  * @TODO: prettify by hiding postdata until requested, either with hidden layers or other means
@@ -263,7 +263,7 @@ if ($action != '')
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <meta charset="<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 </head>
 <body>

--- a/admin/coupon_admin_export.php
+++ b/admin/coupon_admin_export.php
@@ -3,10 +3,10 @@
  * Coupon Exporter
  *
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: coupon_admin_export.php 19537 2013-04-25 04:25:00Z ajeh $
+ * @version $Id: coupon_admin_export.php  Modified in v1.6.0 $
  *
  */
 require ('includes/application_top.php');
@@ -228,7 +228,7 @@ if ($action != '')
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <meta charset="<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 </head>
 <body>

--- a/admin/includes/admin_html_head.php
+++ b/admin/includes/admin_html_head.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: admin_html_head.php $
+ * @version $Id: admin_html_head.php  New in v1.6.0 $
  */
 ?>
 <!doctype html>
@@ -13,7 +13,7 @@
 
 <head>
 <meta charset="<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" href="favicon.ico" type="image/x-icon" />
 <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />

--- a/admin/includes/admin_html_head_index.php
+++ b/admin/includes/admin_html_head_index.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: admin_html_head_index.php $
+ * @version $Id: admin_html_head_index.php  New in v1.6.0 $
  */
 ?>
 <!doctype html>
@@ -13,7 +13,7 @@
 
 <head>
 <meta charset="<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" href="favicon.ico" type="image/x-icon" />
 <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />

--- a/admin/includes/init_includes/init_templates.php
+++ b/admin/includes/init_includes/init_templates.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2010 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: init_templates.php 15995 2010-04-19 17:41:54Z drbyte $
+ * @version $Id: init_templates.php  Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -27,3 +27,23 @@ if (!isset($template_dir) || $template_dir == '') {
  */
   header("Content-Type: text/html; charset=" . CHARSET);
 
+/**
+ * set HTML <title> tag for admin pages
+ */
+$pagename = '';
+if (isset($_GET['cmd'])) {
+  $pagename = $_GET['cmd'];
+  if ($_GET['cmd'] == 'configuration') {
+    $pagename .= " ". zen_get_configuration_group_value($_GET['gID']);
+  }
+}
+if ($pagename == '') {
+  $pagename = preg_replace('/\.php$/', '', basename($PHP_SELF));
+}
+$pagename = str_replace('_', ' ', $pagename);
+$pagename = ucwords($pagename);
+if ($pagename == '') {
+  $pagename = STORE_NAME;
+}
+$title = TEXT_ADMIN_TAB_PREFIX. ' ' . $pagename;
+define('ADMIN_TITLE', $title);

--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -27,6 +27,10 @@ define('HEADER_LOGO_IMAGE', 'logo.gif');
   }
   require(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/' . $template_dir_select . 'meta_tags.php');
 
+// used for prefix to browser tabs in admin pages
+define('TEXT_ADMIN_TAB_PREFIX', 'Admin ');
+//define('TEXT_ADMIN_TAB_PREFIX', 'Admin ' . STORE_NAME);  // if you have multiple stores and want the Store Name to be part of the admin title (ie: for browser tabs), swap this line with the one above
+
 // meta tags
 define('ICON_METATAGS_ON', 'Meta Tags Defined');
 define('ICON_METATAGS_OFF', 'Meta Tags Undefined');

--- a/admin/includes/template/common/tplAdminHtmlHead.php
+++ b/admin/includes/template/common/tplAdminHtmlHead.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: $
+ * @version $Id:   New in v1.6.0 $
  */
 ?>
 <!doctype html>
@@ -12,7 +12,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" <?php echo HTML_PARAMS; ?>> <!--<![endif]-->
 <head>
 <meta charset="<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <meta name="robots" content="noindex, nofollow">
 <link rel="icon" href="favicon.ico" type="image/x-icon" />
 <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />

--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: invoice.php 19136 2011-07-18 16:56:18Z wilt $
+ * @version $Id: invoice.php  Modified in v1.6.0 $
 */
 
   require('includes/application_top.php');
@@ -33,7 +33,7 @@
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <script type="text/javascript" src="includes/menu.js"></script>
 <script type="text/javascript">

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.4 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.6.0 $
  *
  * @TODO - add jquery validation to the password-reset fields, to show when passwords don't match
  * @TODO - add optional PCI-compliance indicator to password field, to show when password isn't compliant
@@ -75,7 +75,7 @@ if ($expired && $message == '') $message = sprintf(ERROR_PASSWORD_EXPIRED . ' ' 
 <html xmlns="http://www.w3.org/1999/xhtml" <?php echo HTML_PARAMS; ?>>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/template/css/foundation.min.css">
 <link href="includes/template/css/login.css" rel="stylesheet" type="text/css" />
 <meta name="robots" content="noindex, nofollow" />

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: packingslip.php 15788 2010-04-02 10:44:40Z drbyte $
+ * @version $Id: packingslip.php  Modified in v1.6.0 $
 */
 
   require('includes/application_top.php');
@@ -36,7 +36,7 @@
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <script type="text/javascript" src="includes/menu.js"></script>
 </head>

--- a/admin/password_forgotten.php
+++ b/admin/password_forgotten.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Sun Jul 22 20:55:36 2012 +0100 Modified in v1.5.1 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.6.0 $
  */
 // reset-token is good for only 24 hours:
 define('ADMIN_PWD_TOKEN_DURATION', (24 * 60 * 60) );
@@ -73,7 +73,7 @@ if (isset($_POST['submit']))
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <meta name="robots" content="noindex, nofollow" />
 <link rel="stylesheet" type="text/css" href="includes/template/css/foundation.min.css">
 <link href="includes/template/css/login.css" rel="stylesheet" type="text/css">

--- a/admin/salemaker_info.php
+++ b/admin/salemaker_info.php
@@ -1,24 +1,12 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: salemaker_info.php 1969 2005-09-13 06:57:21Z drbyte $
-//
+/**
+ * @package admin
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: salemaker_info.php  Modified in v1.6.0 $
+ */
+
   require("includes/application_top.php");
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . FILENAME_SALEMAKER_INFO . '.php');
@@ -27,7 +15,7 @@
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 </head>
 <body>
@@ -42,4 +30,3 @@
 </html>
 <?php
   require(DIR_WS_INCLUDES . 'application_bottom.php');
-?>

--- a/admin/salemaker_popup.php
+++ b/admin/salemaker_popup.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2006 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: salemaker_popup.php 5498 2007-01-01 04:10:07Z ajeh $
+ * @version $Id: salemaker_popup.php  Modified in v1.6.0 $
  */
-//
+
   require("includes/application_top.php");
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . FILENAME_SALEMAKER_POPUP . '.php');
@@ -17,7 +17,7 @@
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=<?php echo CHARSET; ?>">
-<title><?php echo TITLE; ?></title>
+<title><?php echo ADMIN_TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 </head>
 <body>
@@ -80,4 +80,3 @@
 </html>
 <?php
   require(DIR_WS_INCLUDES . 'application_bottom.php');
-?>

--- a/includes/languages/english/meta_tags.php
+++ b/includes/languages/english/meta_tags.php
@@ -1,38 +1,20 @@
 <?php
 /**
  * @package languageDefines
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: meta_tags.php 18697 2011-05-04 14:35:20Z wilt $
+ * @version $Id: meta_tags.php  Modified in v1.5.4 $
  */
 
 // page title
-if (IS_ADMIN_FLAG) 
-{
-  $pagename = '';
-  if (isset($_GET['cmd'])) { 
-     $pagename = $_GET['cmd']; 
-     if ($_GET['cmd'] == 'configuration') { 
-         $pagename .= " ". zen_get_configuration_group_value($_GET['gID']); 
-     }
-     $pagename = str_replace("_", " ", $pagename); 
-     $pagename = ucwords($pagename); 
-  }
-  // If you have multiple stores you may wish to add the STORE_NAME
-  // $title = 'Admin '. STORE_NAME . " " . $pagename; 
-  $title = 'Admin '. $pagename; 
-  define('TITLE', $title); 
-} else 
-{
   define('TITLE', STORE_NAME);
-}
 
 // Site Tagline
-define('SITE_TAGLINE', 'The Art of E-commerce');
+  define('SITE_TAGLINE', 'The Art of E-commerce');
 
 // Custom Keywords
-define('CUSTOM_KEYWORDS', 'ecommerce, open source, shop, online shopping, store');
+  define('CUSTOM_KEYWORDS', 'ecommerce, open source, shop, online shopping, store');
 
 // Home Page Only:
   define('HOME_PAGE_META_DESCRIPTION', '');


### PR DESCRIPTION
Removes the Admin `TITLE` logic from the catalog language file, into admin init_templates script, so the catalog-side file is now catalog-only. (Note: the admin still reads the file to allow for some display elements to offer "preview" capability from within the admin)

Uses new constant `ADMIN_TITLE` as distinct from the catalog-side `TITLE`

Builds the name from the `cmd` value, as per submission by @scottcwilson in #307

Catches missing names to allow fallback detection for plugins that might not get upgraded properly

Minor whitespace cleanup to the catalog meta_tags.php language file.