### PR TITLE
Initial commit for refactored pagination classes

### DIFF
--- a/includes/library/zencart/platform/src/Paginator/AbstractAdapter.php
+++ b/includes/library/zencart/platform/src/Paginator/AbstractAdapter.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Class AbstractAdapter
+ *
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: $
+ */
+namespace ZenCart\Platform\Paginator;
+/**
+ * Class AbstractAdapter
+ * @package ZenCart\Platform\Paginator
+ */
+abstract class AbstractAdapter extends \base
+{
+    /**
+     * Results
+     *
+     * @var array
+     */
+    protected $results = array();
+
+    /**
+     * constructor
+     *
+     * @param array $data
+     * @param array $params
+     */
+    public function __construct(array $data, array $params = array())
+    {
+        $this->notify('NOTIFY_PAGINATOR_ADAPTER_CONSTRUCT_START', $data, $params);
+        $params['currentPage'] = (isset($params['currentPage'])) ? $params['currentPage'] : 1;
+        $params['itemsPerPage'] = (isset($params['itemsPerPage'])) ? $params['itemsPerPage'] : 10;
+        $params['currentItem'] = ($params['currentPage'] - 1) * $params['itemsPerPage'] + 1;
+        $this->notify('NOTIFY_PAGINATOR_ADAPTER_CONSTRUCT_END', $data, $params);
+        $this->process($data, $params);
+    }
+
+    /**
+     * process method
+     *
+     * @return array
+     */
+    public function process($data, $params)
+    {
+        $results = array();
+        $this->notify('NOTIFY_PAGINATOR_ADAPTER_PROCESS_START', $data, $params);
+        $results['currentItem'] = $params['currentItem'];
+        $results['itemsPerPage'] = $params['itemsPerPage'];
+        $results['totalItemCount'] = $this->getTotalItemCount($data);
+        $results['resultList'] = $this->getResultList($data, $params);
+        $results['totalPages'] = ceil($results['totalItemCount'] / $params['itemsPerPage']);
+        $this->results = $results;
+        $this->notify('NOTIFY_PAGINATOR_ADAPTER_PROCESS_END');
+    }
+
+    /**
+     * @return array
+     */
+    public function getResults()
+    {
+        $this->notify('NOTIFY_PAGINATOR_ADAPTER_GETRESULTS_START');
+        return $this->results;
+    }
+}

--- a/includes/library/zencart/platform/src/Paginator/AbstractScroller.php
+++ b/includes/library/zencart/platform/src/Paginator/AbstractScroller.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class AbstractScroller
+ *
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: $
+ */
+namespace ZenCart\Platform\Paginator;
+/**
+ * Class AbstractScroller
+ * @package ZenCart\Platform\Paginator
+ */
+abstract class AbstractScroller extends \base
+{
+    /**
+     * results
+     *
+     * @var array
+     */
+    protected $results = array();
+
+    /**
+     * constructor
+     *
+     * @param array $params
+     */
+    public function __construct(AdapterInterface $adapter, array $params)
+    {
+        $this->notify('NOTIFY_PAGINATOR_SCROLLER_CONSTRUCT_START', $params);
+        $params['pagingVarName'] = isset($params['pagingVarName']) ? $params['pagingVarName'] : 'page';
+        $params['currentPage'] = isset($params['currentPage']) ? $params['currentPage'] : 1;
+        $params['scrollerLinkParams'] = isset($params['scrollerLinkParams']) ? $params['scrollerLinkParams'] : '';
+        $params['maxPageLinks'] = isset($params['maxPageLinks']) ? $params['maxPageLinks'] : 5;
+        $this->notify('NOTIFY_PAGINATOR_SCROLLER_BEFORE_PROCESS', $params);
+        $this->process($adapter->getResults(), $params);
+        $this->results['resultList'] = $adapter->getResults()['resultList'];
+        $this->notify('NOTIFY_PAGINATOR_SCROLLER_CONSTRUCT_END');
+    }
+
+    /**
+     * @param array $data
+     * @param array $params
+     * @return mixed
+     */
+    abstract protected function process(array $data, array $params);
+
+    /**
+     * buildLink method
+     *
+     * @param $params
+     * @return string
+     */
+    public function buildLink($params)
+    {
+        $link = zen_href_link($params['cmd'], $params['linkParams']);
+        return $link;
+    }
+
+    /**
+     * getCurrentLinkParams method
+     *
+     * @param $params
+     * @return mixed|string
+     */
+    public function getRequestParams($params)
+    {
+        $linkParams = zen_get_all_get_params($params['exclude'], $params['linkParams']);
+        return $linkParams;
+    }
+
+    /**
+     * @return array
+     */
+    public function getResults()
+    {
+        $this->notify('NOTIFY_PAGINATOR_SCROLLER_GETRESULTS_START');
+        return $this->results;
+    }
+}

--- a/includes/library/zencart/platform/src/Paginator/AdapterInterface.php
+++ b/includes/library/zencart/platform/src/Paginator/AdapterInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Interface AdapterInterface
+ *
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: $
+ */
+namespace ZenCart\Platform\Paginator;
+/**
+ * Interface AdapterInterface
+ * @package ZenCart\Platform\Paginator
+ */
+interface AdapterInterface
+{
+    /**
+     * getResultList method
+     * @return array
+     */
+    public function getResultList($data, $params);
+
+    /**
+     * getTotalItemCount method
+     *
+     * @return integer
+     */
+    public function getTotalItemCount($data);
+}

--- a/includes/library/zencart/platform/src/Paginator/Paginator.php
+++ b/includes/library/zencart/platform/src/Paginator/Paginator.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Class Paginator
+ *
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: $
+ */
+namespace ZenCart\Platform\Paginator;
+
+use Instantiator\Exception\InvalidArgumentException;
+
+/**
+ * Class Paginator
+ * @package ZenCart\Platform\Paginator
+ */
+class Paginator extends \base
+{
+    /**
+     * @var mixed
+     */
+    protected $adapter;
+    
+    /**
+     * @var mixed
+     */
+    protected $scroller;
+
+    /**
+     * @param \ZenCart\Platform\Request $request
+     * @param $adapterType
+     * @param $scrollerType
+     * @param $adapterData
+     * @param $adapterParams
+     * @param $scrollerParams
+     */
+    public function __construct(\ZenCart\Platform\Request $request, $adapterType, $scrollerType, $adapterData, $adapterParams, $scrollerParams)
+    {
+        $pagingVarName = isset($scrollerParams['pagingVarName']) ? $scrollerParams['pagingVarName'] : 'page';
+        $pagingVarSrc = isset($scrollerParams['pagingVarSrc']) ? $scrollerParams['pagingVarSrc'] : 'get';
+        $currentPage = $request->get($pagingVarName, 1, $pagingVarSrc);
+        $adapterParams['currentPage'] = $currentPage;
+        $scrollerParams['currentPage'] = $currentPage;
+        $this->adapter = $this->buildAdapter($adapterType, $adapterData, $adapterParams);
+        $this->scroller = $this->buildScroller($scrollerType, $this->adapter, $scrollerParams);
+    }
+
+    /**
+     * @param $adapterType
+     * @param array $adapterData
+     * @param array $adapterParams
+     * @return mixed
+     */
+    protected function buildAdapter($adapterType, array $adapterData, array $adapterParams)
+    {
+        $className = __NAMESPACE__ . '\\adapters\\' . ucfirst($adapterType);
+        $obj = new $className($adapterData, $adapterParams);
+        return $obj;
+    }
+
+    /**
+     * @param $scrollerType
+     * @param array $adapter
+     * @param array $scrollerParams
+     * @return mixed
+     */
+    protected function buildScroller($scrollerType, \ZenCart\Platform\Paginator\AdapterInterface $adapter, array $scrollerParams)
+    {
+        $className = __NAMESPACE__ . '\\scrollers\\' . ucfirst($scrollerType);
+        $obj = new $className($adapter, $scrollerParams);
+        return $obj;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getScroller()
+    {
+        return $this->scroller;
+    }
+}

--- a/includes/library/zencart/platform/src/Paginator/adapters/QueryFactory.php
+++ b/includes/library/zencart/platform/src/Paginator/adapters/QueryFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Class QueryFactory
+ *
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: $
+ */
+namespace ZenCart\Platform\Paginator\adapters;
+
+use ZenCart\Platform\Paginator\AdapterInterface;
+use ZenCart\Platform\Paginator\AbstractAdapter;
+
+/**
+ * Class QueryFactory
+ * @package ZenCart\Platform\Paginator\adapters
+ */
+class QueryFactory extends AbstractAdapter implements AdapterInterface
+{
+    /**
+     * getResultList method
+     *
+     * @return array|mixed
+     */
+    public function getResultList($data, $params)
+    {
+        $limit = $params['currentItem'] - 1 . ',' . $params['itemsPerPage'];
+        $results = $data['dbConn']->execute($data['sqlQueries']['main'], $limit);
+        $resultList = array();
+        foreach ($results as $result) {
+            $resultList[] = $result;
+        }
+        return $resultList;
+    }
+
+    /**
+     * getTotalItemCount method
+     *
+     * @return integer
+     */
+    public function getTotalItemCount($data)
+    {
+        $result = $data['dbConn']->execute($data['sqlQueries']['count']);
+        return $result->fields['total'];
+    }
+} 

--- a/includes/library/zencart/platform/src/Paginator/scrollers/Standard.php
+++ b/includes/library/zencart/platform/src/Paginator/scrollers/Standard.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Class Standard
+ *
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: $
+ */
+namespace ZenCart\Platform\Paginator\scrollers;
+
+use ZenCart\Platform\Paginator\ScrollerInterface;
+use ZenCart\Platform\Paginator\AbstractScroller;
+
+/**
+ * Class Standard
+ * @package ZenCart\Platform\Paginator\scrollers
+ */
+class Standard extends AbstractScroller
+{
+    /**
+     * process method
+     *
+     * @return mixed|void
+     */
+    protected function process(array $data, array $params)
+    {
+        $results = array();
+        $linkParams = $params['scrollerLinkParams'];
+        $maxPageLinks = $params['maxPageLinks'];
+        $pageVarName = $params['pagingVarName'];
+        $cmd = $params['cmd'];
+
+        if (!isset ($params['disableZenGetAllGetParams'])) {
+            $linkParams = $this->getRequestParams(array('exclude' => array($pageVarName, 'action'),
+                                                        'linkParams' => $linkParams));
+        }
+        $pageNumber = intval($params['currentPage'] / $maxPageLinks);
+        if ($params['currentPage'] % $maxPageLinks) {
+            $pageNumber++;
+        }
+        $linkList = $this->buildLinkList($pageNumber, $linkParams, $data, $params);
+        $results['linkList'] = $linkList;
+        $results['hasItems'] = (count($linkList) > 0);
+        $results['nextPage'] = $params['currentPage'] + 1;
+        $results['prevPage'] = $params['currentPage'] - 1;
+        $results['fromItem'] = $data['currentItem'];
+        $results['toItem'] = $data['currentItem'] + $data['itemsPerPage'] - 1;
+        $results['flagHasPrevious'] = $data['currentItem'] > 1 ? true : false;
+        $results['flagHasNext'] = $params['currentPage'] < $data['totalPages'] ? true : false;
+
+        $buildLinkParams = array('cmd' => $cmd,
+                                 'linkParams' => $linkParams . $pageVarName . '=' . ($params['currentPage'] - 1));
+        $results['previousLink'] = $this->buildLink($buildLinkParams);
+        $buildLinkParams = array('cmd' => $cmd,
+                                 'linkParams' => $linkParams . $pageVarName . '=' . ($params['currentPage'] + 1));
+        $results['nextLink'] = $this->buildLink($buildLinkParams);
+        $this->results = $results;
+    }
+
+    /**
+     * buildItemList method
+     *
+     * @param $pageNumber
+     * @param $linkParams
+     * @return array
+     */
+    protected function buildLinkList($pageNumber, $linkParams, $data, $params)
+    {
+        $pageCount = $data['totalPages'];
+        $maxPageLinks = $params['maxPageLinks'];
+        $pageVarName = $params['pagingVarName'];
+        $cmd = $params['cmd'];
+        $currentPage = $params['currentPage'];
+
+        $linkList = array();
+        if ($pageCount <= 1) {
+            return $linkList;
+        }
+        for ($i = 1 + (($pageNumber - 1) * $maxPageLinks); ($i <= ($pageNumber * $maxPageLinks)) && ($i <= $pageCount); $i++) {
+            $buildLinkParams = array('cmd' => $cmd, 'linkParams' => $linkParams . $pageVarName . '=' . $i);
+            $linkList[] = array(
+                'itemNumber' => $i,
+                'itemLink' => $this->buildLink($buildLinkParams),
+                'isCurrent' => ($i == $currentPage) ? true : false
+            );
+        }
+        return $linkList;
+    }
+}

--- a/testFramework/unittests/paginator/paginatorAdapterTest.php
+++ b/testFramework/unittests/paginator/paginatorAdapterTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * File contains paginator adapter test cases
+ *
+ * @package tests
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id$
+ */
+require_once(__DIR__ . '/../support/zcPaginatorTestCase.php');
+use ZenCart\Platform\Paginator\adapters\QueryFactory;
+/**
+ * Testing Library
+ */
+class testPaginationAdapterCase extends zcPaginatorTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'db/mysql/query_factory.php';
+        require DIR_CATALOG_LIBRARY . 'aura/autoload/src/Loader.php';
+        $loader = new \Aura\Autoload\Loader;
+        $loader->register();
+        $loader->addPrefix('\ZenCart\Platform', DIR_CATALOG_LIBRARY . 'zencart/platform/src');
+    }
+
+    public function testRunAdapter()
+    {
+        $db = $this->getMock('queryFactory');
+        $db0 = clone($db);
+        $db1 = array(array('foo'=>'bar'), array('foo'=>'bar1'));
+        $db0->fields = array('total'=>'2');
+        $db->method('execute')
+            ->will($this->onConsecutiveCalls($db0, $db1));
+        $data = array('sqlQueries'=>array('main'=>'', 'count'=>''), 'dbConn'=>$db);
+        $parameters = array('pagingVarName'=>'page', 'currentItem'=>1, 'itemsPerPage'=>2);
+        $ds = new QueryFactory($data, $parameters);
+        $dsr = $ds->getResults();
+        $this->assertTrue(is_array($dsr));
+        $this->assertTrue($dsr['totalItemCount'] == 2);
+        $this->assertTrue(count($dsr['resultList']) == 2);
+    }
+
+    public function testStaticBuild()
+    {
+        $db = $this->getMock('queryFactory');
+        $db0 = clone($db);
+        $db1 = array(array('foo'=>'bar'), array('foo'=>'bar1'));
+        $db0->fields = array('total'=>'2');
+        $db->method('execute')
+            ->will($this->onConsecutiveCalls($db0, $db1));
+        $data = array('sqlQueries'=>array('main'=>'', 'count'=>''), 'dbConn'=>$db);
+
+    }
+}

--- a/testFramework/unittests/paginator/paginatorScrollerTest.php
+++ b/testFramework/unittests/paginator/paginatorScrollerTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * File contains Paginator Scroller test cases
+ *
+ * @package tests
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id$
+ */
+require_once(__DIR__ . '/../support/zcPaginatorTestCase.php');
+use ZenCart\Platform\Paginator\scrollers\Standard;
+/**
+ * Testing Library
+ */
+class testPaginationScrollerCase extends zcPaginatorTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        require_once(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'sessions.php');
+        require_once(DIR_FS_ADMIN . DIR_WS_FUNCTIONS . 'html_output.php');
+        require DIR_CATALOG_LIBRARY . 'aura/autoload/src/Loader.php';
+        $loader = new \Aura\Autoload\Loader;
+        $loader->register();
+        $loader->addPrefix('\ZenCart\Platform', DIR_CATALOG_LIBRARY . 'zencart/platform/src');
+    }
+
+    public function testRunScrollerWithResults()
+    {
+        $ds = $this->getMockBuilder('\\ZenCart\\Platform\\Paginator\\adapters\\QueryFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $ds->method('getResults')->willReturn(array('totalPages'=>10, 'currentItem'=>1, 'itemsPerPage'=>10, 'resultList'=>array()));
+        $params = array('pagingVarName'=>'page', 'scrollerLinkParams'=>'', 'itemsPerPage'=>'10', 'currentItem'=>'1', 'currentPage'=>'1', 'maxPageLinks'=>'10', 'cmd'=>'countries');
+        $scroller = new Standard($ds, $params);
+        $dsr = $scroller->getResults();
+        $this->assertTrue(is_array($dsr));
+        $this->assertTrue(is_array($dsr['linkList']));
+        $this->assertTrue($dsr['hasItems']);
+        $this->assertTrue($dsr['nextPage'] == 2);
+        $this->assertTrue($dsr['prevPage'] == 0);
+    }
+    public function testRunScrollerWithNoResults()
+    {
+        $ds = $this->getMockBuilder('\\ZenCart\\Platform\\Paginator\\adapters\\QueryFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $ds->method('getResults')->willReturn(array('totalPages'=>0, 'currentItem'=>1, 'itemsPerPage'=>10, 'resultList'=>array()));
+        $params = array('pagingVarName'=>'page', 'scrollerLinkParams'=>'', 'itemsPerPage'=>'10', 'currentItem'=>'0', 'currentPage'=>'0', 'maxPageLinks'=>'10', 'totalPages'=>'0', 'cmd'=>'countries');
+        $scroller = new Standard($ds, $params);
+        $dsr = $scroller->getResults();
+        $this->assertTrue(is_array($dsr));
+        $this->assertTrue(is_array($dsr['linkList']));
+        $this->assertFalse($dsr['hasItems']);
+        $this->assertTrue($dsr['nextPage'] == 1);
+        $this->assertTrue($dsr['prevPage'] == -1);
+    }
+}

--- a/testFramework/unittests/paginator/paginatorTest.php
+++ b/testFramework/unittests/paginator/paginatorTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File contains Paginator test cases
+ *
+ * @package tests
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id$
+ */
+require_once(__DIR__ . '/../support/zcPaginatorTestCase.php');
+use ZenCart\Platform\Paginator\Paginator;
+/**
+ * Testing Library
+ */
+class testPaginationCase extends zcPaginatorTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'db/mysql/query_factory.php';
+        require DIR_CATALOG_LIBRARY . 'aura/autoload/src/Loader.php';
+        $loader = new \Aura\Autoload\Loader;
+        $loader->register();
+        $loader->addPrefix('\ZenCart\Platform', DIR_CATALOG_LIBRARY . 'zencart/platform/src');
+    }
+
+    public function testMain()
+    {
+        $r = $this->getMockBuilder('\\ZenCart\\Platform\\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $db = $this->getMock('queryFactory');
+        $db0 = clone($db);
+        $db1 = array(array('foo'=>'bar'), array('foo'=>'bar1'));
+        $db0->fields = array('total'=>'2');
+        $db->method('execute')
+            ->will($this->onConsecutiveCalls($db0, $db1));
+
+        $adapterData = array('dbConn'=>$db, 'sqlQueries'=>array('main'=>'', 'count'=>''));
+        $scrollerParams = array('cmd'=>'index');
+        $p = new Paginator($r, 'QueryFactory', 'Standard', $adapterData, array(), $scrollerParams);
+        $a = $p->getAdapter();
+        $s = $p->getScroller();
+    }
+}

--- a/testFramework/unittests/phpunit.xml
+++ b/testFramework/unittests/phpunit.xml
@@ -37,6 +37,10 @@
       <file>testAdminLoggingCase.php</file>
     </testsuite>
 
+    <testsuite name="Paginator">
+      <directory suffix="Test.php">paginator</directory>
+    </testsuite>
+
   </testsuites>
 
   <logging>

--- a/testFramework/unittests/support/zcPaginatorTestCase.php
+++ b/testFramework/unittests/support/zcPaginatorTestCase.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * File contains support for paginator unit tests
+ *
+ * @package tests
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id$
+ */
+
+/**
+ * Testing Library
+ */
+abstract class zcPaginatorTestCase extends PHPUnit_Framework_TestCase
+{
+    public function run(PHPUnit_Framework_TestResult $result = NULL)
+    {
+        $this->setPreserveGlobalState(false);
+        return parent::run($result);
+    }
+
+    public function setUp()
+    {
+        // Define some pre-requisites
+        global $zco_notifier;
+        define('IS_ADMIN_FLAG', 'TRUE');
+        if(!defined('TESTCWD')) define('TESTCWD', realpath(__DIR__ . '/../') . '/');
+        if(!defined('DIR_FS_CATALOG')) define('DIR_FS_CATALOG', realpath(__DIR__ . '/../../../') . '/');
+        if(!defined('DIR_FS_INCLUDES')) define('DIR_FS_INCLUDES', DIR_FS_CATALOG . 'includes/');
+        if(!defined('CWD')) define('CWD', DIR_FS_INCLUDES . '../');
+        if (!defined('DIR_CATALOG_LIBRARY')) define('DIR_CATALOG_LIBRARY', DIR_FS_INCLUDES . 'library/');
+
+        if (strpos(@ini_get('include_path'), '.') === false)
+        {
+            @ini_set('include_path', '.' . PATH_SEPARATOR . @ini_get('include_path'));
+        }
+
+        if (file_exists(TESTCWD . 'localTestSetup.php'))
+            require_once TESTCWD . 'localTestSetup.php';
+
+        // Configure some additional paths if not already configured
+        if(!defined('DIR_WS_ADMIN')) define('DIR_WS_ADMIN', '/admin/');
+        if(!defined('DIR_FS_ADMIN')) define('DIR_FS_ADMIN', DIR_FS_CATALOG . 'admin/');
+        if(!defined('DIR_WS_CATALOG')) define('DIR_WS_CATALOG', '/');
+        if(!defined('DIR_WS_HTTPS_CATALOG')) define('DIR_WS_HTTPS_CATALOG', '/ssl/');
+
+        // Configure the rest of the paths if needed
+        require_once(DIR_FS_INCLUDES . 'defined_paths.php');
+        // Load required common files
+        require_once(DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.base.php');
+        require_once(DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.notifier.php');
+        if(!defined('HTTP_SERVER'))
+            define('HTTP_SERVER', 'http://zencart-git.local');
+        if(!defined('DIR_WS_CATALOG'))
+            define('DIR_WS_CATALOG', '/');
+        if(!defined('DIR_WS_HTTPS_CATALOG'))
+            define('DIR_WS_HTTPS_CATALOG', '/ssl/');
+
+        // Configure required language defines
+        if(!defined('CONNECTION_TYPE_UNKNOWN'))
+            define('CONNECTION_TYPE_UNKNOWN', 'Unknown Connection \'%s\' Found: %s');
+
+        require_once(DIR_FS_CATALOG . DIR_WS_INCLUDES . 'filenames.php');
+
+        $zco_notifier = new notifier;
+        if(IS_ADMIN_FLAG)
+        {
+            require_once(DIR_FS_ADMIN . DIR_WS_FUNCTIONS . 'general.php');
+            require_once(DIR_FS_ADMIN . DIR_WS_FUNCTIONS . 'html_output.php');
+        }
+        else
+        {
+            require_once(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'functions_general.php');
+        }
+
+        require_once(DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.zcPassword.php');
+        require_once(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'password_funcs.php');
+
+
+    }
+}


### PR DESCRIPTION
This is a refactoring of the previous new paginator classes, which were meant as a replacement for
the old split_page_results classes in admin/catalog.
The classes have been simplified and moved into the autoloaded library directory.
Note also, that I have not removed the old paginator classes, as these are still used by the listingBox
infrastructure. Once that is refactored they will be removed.

Also. There are some nascent docs at 
http://docs.zen-cart.com/index.php/Developer_Documentation/1.6/code_docs/pagination/pagination