### PR TITLE
Rename zen_orders_products_downloads() to zen_verify_download_file_is_valid()

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -1536,7 +1536,7 @@ if ($action == '') {
         if ($download_display->RecordCount() > 0) {
 
   $filename_is_missing='';
-  if ( !zen_orders_products_downloads($download_display->fields['products_attributes_filename']) ) {
+  if ( !zen_verify_download_file_is_valid($download_display->fields['products_attributes_filename']) ) {
     $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_red.gif');
   } else {
     $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_green.gif');

--- a/admin/downloads_manager.php
+++ b/admin/downloads_manager.php
@@ -125,7 +125,7 @@ function go_option() {
     }
 
     $filename_is_missing='';
-    if ( !zen_orders_products_downloads($products_downloads_query->fields['products_attributes_filename']) ) {
+    if ( !zen_verify_download_file_is_valid($products_downloads_query->fields['products_attributes_filename']) ) {
       $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_red.gif');
     } else {
       $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_green.gif');

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2516,7 +2516,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
       if ($check_valid == true) {
         $valid_downloads = '';
         while (!$download_display->EOF) {
-          if (!file_exists(zen_get_download_handler($download_display->fields['products_attributes_filename']))) {
+          if (!zen_verify_download_file_is_valid($download_display->fields['products_attributes_filename'])) {
             $valid_downloads .= '<br />&nbsp;&nbsp;' . zen_image(DIR_WS_IMAGES . 'icon_status_red.gif') . ' Invalid: ' . $download_display->fields['products_attributes_filename'];
             // break;
           } else {
@@ -2670,7 +2670,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     global $db;
     $configuration_query= $db->Execute("select configuration_group_title from " . TABLE_CONFIGURATION_GROUP . " where configuration_group_id ='" . (int)$lookup . "'");
     if ( $configuration_query->RecordCount() == 0 ) {
-      return (int)$lookup; 
+      return (int)$lookup;
     }
     return $configuration_query->fields['configuration_group_title'];
   }
@@ -3263,7 +3263,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
 /**
  * check that the specified download filename exists on the filesystem
  */
-  function zen_orders_products_downloads($check_filename) {
+  function zen_verify_download_file_is_valid($check_filename) {
     global $zco_notifier;
 
     $handler = zen_get_download_handler($check_filename);

--- a/admin/includes/modules/orders_download.php
+++ b/admin/includes/modules/orders_download.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2011 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: orders_download.php 18695 2011-05-04 05:24:19Z drbyte $
+ * @version $Id: orders_download.php drbyte  Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -64,7 +64,7 @@ if (!defined('IS_ADMIN_FLAG')) {
       }
 
 // if not on server show red
-      if (!zen_orders_products_downloads($orders_download->fields['orders_products_filename'])) {
+      if (!zen_verify_download_file_is_valid($orders_download->fields['orders_products_filename'])) {
         $zc_file_status = zen_image(DIR_WS_IMAGES . 'icon_red_on.gif', IMAGE_ICON_STATUS_OFF);
       }
 ?>


### PR DESCRIPTION
Rename zen_orders_products_downloads() to zen_verify_download_file_is_valid() to better capture the meaning of what it's doing.

Added one more place where it's used, too.