### PR TITLE
Correctly check admin module 'key' counts

### DIFF
--- a/admin/modules.php
+++ b/admin/modules.php
@@ -181,32 +181,31 @@ require('includes/admin_html_head.php');
       include($module_directory . $file);
       $class = substr($file, 0, strrpos($file, '.'));
       if (class_exists($class)) {
-          $module = new $class;
-          $check = $module->check();
-          if ($check > 0) {
-              if ($module->sort_order > 0) {
-                  if (isset($installed_modules[$module->sort_order]) && $installed_modules[$module->sort_order] != '') {
-                      $zc_valid = false;
-                  }
-                  $installed_modules[$module->sort_order] = $file;
-              } else {
-                  $installed_modules[] = $file;
-              }
-              if (method_exists($module, 'check_enabled_for_zone') && $module->enabled) $module->check_enabled_for_zone();
-              if (method_exists($module, 'check_enabled') && $module->enabled) $module->check_enabled_for_zone();
+        $module = new $class;
+        $check = $module->check();
+        if ($check > 0) {
+          if ($module->sort_order > 0) {
+            if (isset($installed_modules[$module->sort_order]) && $installed_modules[$module->sort_order] != '') {
+              $zc_valid = false;
+            }
+            $installed_modules[$module->sort_order] = $file;
+          } else {
+            $installed_modules[] = $file;
           }
+          if (method_exists($module, 'check_enabled_for_zone') && $module->enabled) $module->check_enabled_for_zone();
+          if (method_exists($module, 'check_enabled') && $module->enabled) $module->check_enabled_for_zone();
+        }
 
-          //test for missing keys
-          $error = FALSE;
-          if ($module->enabled) {
-            foreach ($module->keys() as $test) {
-              if (!defined($test)) {
-                  $error = TRUE;
-                  break;
-              }
+        //test for missing keys
+        $error = FALSE;
+        if ($module->enabled) {
+          foreach ($module->keys() as $test) {
+            if (!defined($test)) {
+              $error = TRUE;
+              break;
             }
           }
-
+        }
         if ($error) $module->title .= ' ' . WARNING_MODULES_MISSING_KEYS;
 
         if (in_array($set, array('payment', 'shipping'))) {
@@ -224,7 +223,6 @@ require('includes/admin_html_head.php');
                                'status' => $check);
           $module_keys = $module->keys();
           $keys_extra = array();
-          $key_missing = false; 
           for ($j=0, $k=sizeof($module_keys); $j<$k; $j++) {
             $key_value = $db->Execute("select configuration_title, configuration_value, configuration_key,
                                           configuration_description, use_function, set_function
@@ -236,8 +234,6 @@ require('includes/admin_html_head.php');
               $keys_extra[$module_keys[$j]]['description'] = $key_value->fields['configuration_description'];
               $keys_extra[$module_keys[$j]]['use_function'] = $key_value->fields['use_function'];
               $keys_extra[$module_keys[$j]]['set_function'] = $key_value->fields['set_function'];
-            } else { 
-              $key_missing = true; 
             }
           }
           $module_info['keys'] = $keys_extra;

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -197,16 +197,15 @@ require('includes/admin_html_head.php');
         }
 
         //test for missing keys
-        $error = FALSE;
-        if ($module->enabled) {
-          foreach ($module->keys() as $test) {
-            if (!defined($test)) {
-              $error = TRUE;
-              break;
-            }
+        $keycount = 0; 
+        foreach ($module->keys() as $test) {
+          if (defined($test)) {
+            $keycount++; 
           }
         }
-        if ($error) $module->title .= ' ' . WARNING_MODULES_MISSING_KEYS;
+        if ($keycount > 0 && $keycount != sizeof($module->keys())) { 
+           $module->title .= ' ' . WARNING_MODULES_MISSING_KEYS;
+        } 
 
         if (in_array($set, array('payment', 'shipping'))) {
           $moduleStatusIcon = ((!empty($module->enabled) && is_numeric($module->sort_order)) ? zen_image(DIR_WS_IMAGES . 'icon_status_green.gif') : ((empty($module->enabled) && is_numeric($module->sort_order)) ? zen_image(DIR_WS_IMAGES . 'icon_status_yellow.gif') : zen_image(DIR_WS_IMAGES . 'icon_status_red.gif')));

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -181,31 +181,32 @@ require('includes/admin_html_head.php');
       include($module_directory . $file);
       $class = substr($file, 0, strrpos($file, '.'));
       if (class_exists($class)) {
-        $module = new $class;
-        $check = $module->check();
-        if ($check > 0) {
-          if ($module->sort_order > 0) {
-            if (isset($installed_modules[$module->sort_order]) && $installed_modules[$module->sort_order] != '') {
-              $zc_valid = false;
-            }
-            $installed_modules[$module->sort_order] = $file;
-          } else {
-            $installed_modules[] = $file;
+          $module = new $class;
+          $check = $module->check();
+          if ($check > 0) {
+              if ($module->sort_order > 0) {
+                  if (isset($installed_modules[$module->sort_order]) && $installed_modules[$module->sort_order] != '') {
+                      $zc_valid = false;
+                  }
+                  $installed_modules[$module->sort_order] = $file;
+              } else {
+                  $installed_modules[] = $file;
+              }
+              if (method_exists($module, 'check_enabled_for_zone') && $module->enabled) $module->check_enabled_for_zone();
+              if (method_exists($module, 'check_enabled') && $module->enabled) $module->check_enabled_for_zone();
           }
-          if (method_exists($module, 'check_enabled_for_zone') && $module->enabled) $module->check_enabled_for_zone();
-          if (method_exists($module, 'check_enabled') && $module->enabled) $module->check_enabled_for_zone();
-        }
 
-        //test for missing keys
-        $error = FALSE;
-        if (is_numeric($module->sort_order)) {
-          foreach ($module->keys() as $test) {
-            if (!defined($test)) {
-              $error = TRUE;
-              break;
+          //test for missing keys
+          $error = FALSE;
+          if ($module->enabled) {
+            foreach ($module->keys() as $test) {
+              if (!defined($test)) {
+                  $error = TRUE;
+                  break;
+              }
             }
           }
-        }
+
         if ($error) $module->title .= ' ' . WARNING_MODULES_MISSING_KEYS;
 
         if (in_array($set, array('payment', 'shipping'))) {
@@ -223,6 +224,7 @@ require('includes/admin_html_head.php');
                                'status' => $check);
           $module_keys = $module->keys();
           $keys_extra = array();
+          $key_missing = false; 
           for ($j=0, $k=sizeof($module_keys); $j<$k; $j++) {
             $key_value = $db->Execute("select configuration_title, configuration_value, configuration_key,
                                           configuration_description, use_function, set_function
@@ -234,6 +236,8 @@ require('includes/admin_html_head.php');
               $keys_extra[$module_keys[$j]]['description'] = $key_value->fields['configuration_description'];
               $keys_extra[$module_keys[$j]]['use_function'] = $key_value->fields['use_function'];
               $keys_extra[$module_keys[$j]]['set_function'] = $key_value->fields['set_function'];
+            } else { 
+              $key_missing = true; 
             }
           }
           $module_info['keys'] = $keys_extra;

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version GIT: $Id: Author: DrByte  Jun 30 2014 Modified in v1.5.4 $


### PR DESCRIPTION
Fixes admin/modules.php so that module key counts are correctly checked.  This check was skipped because the if statement was incorrect.