### PR TITLE
Fix size/unknown indicators on downloads page

### DIFF
--- a/includes/languages/english/locale.php
+++ b/includes/languages/english/locale.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package languageDefines
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id$
+ * @version $Id:  New in v1.6.0 $
  */
 
 // look in your $PATH_LOCALE/locale directory for available locales..
@@ -61,7 +61,9 @@
   define('TEXT_NUMBER_SYMBOL', '# ');
 
   define('TEXT_FILESIZE_BYTES', ' bytes');
+  define('TEXT_FILESIZE_KBS', ' KB');
   define('TEXT_FILESIZE_MEGS', ' MB');
+  define('TEXT_FILESIZE_UNKNOWN', 'Unknown');
 
 // misc
   define('COLON_SPACER', ':&nbsp;&nbsp;');

--- a/includes/modules/downloads.php
+++ b/includes/modules/downloads.php
@@ -88,10 +88,8 @@ if ($downloadsOnThisOrder) {
 
     // calculate filesize/units
     $zv_filesize_units = '';
-    $zv_filesize = 0;
-    if ($data['filesize'] == 0) {
-      $zv_filesize = TEXT_FILESIZE_UNKNOWN;
-    } else {
+    $zv_filesize = TEXT_FILESIZE_UNKNOWN;
+    if ($data['filesize'] > 0) {
       $zv_filesize = $data['filesize'];
       if ($zv_filesize >= 11000) {
         $zv_filesize = number_format($zv_filesize/1024/1024,1);

--- a/includes/modules/downloads.php
+++ b/includes/modules/downloads.php
@@ -85,13 +85,20 @@ if ($downloadsOnThisOrder) {
     $data['link_url'] = zen_href_link(FILENAME_DOWNLOAD, 'order=' . $last_order . '&id=' . $data['orders_products_download_id']);
 
     $data['filesize'] = ($data['file_exists']) ? filesize(DIR_FS_DOWNLOAD . $data['orders_products_filename']) : 0;
+
+    // calculate filesize/units
+    $zv_filesize_units = '';
+    $zv_filesize = 0;
     if ($data['filesize'] == 0) {
-      $zv_filesize_units = 'Unknown';
+      $zv_filesize = TEXT_FILESIZE_UNKNOWN;
     } else {
       $zv_filesize = $data['filesize'];
-      if ($zv_filesize >= 1024) {
+      if ($zv_filesize >= 11000) {
         $zv_filesize = number_format($zv_filesize/1024/1024,1);
         $zv_filesize_units = TEXT_FILESIZE_MEGS;
+      } else if ($zv_filesize >= 1024) {
+        $zv_filesize = number_format($zv_filesize/1024,1);
+        $zv_filesize_units = TEXT_FILESIZE_KBS;
       } else {
         $zv_filesize = number_format($zv_filesize);
         $zv_filesize_units = TEXT_FILESIZE_BYTES;


### PR DESCRIPTION
Ajeh spotted that the display of MB/bytes on the downloads page had some problems after the commits in #327