### PR TITLE
Add new issetorArray function

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -4,7 +4,7 @@
  * General functions used throughout Zen Cart
  *
  * @package functions
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version GIT: $Id: Author: Ian Wilson  Wed Feb 19 15:57:35 2014 +0000 Modified in v1.5.3 $
@@ -1634,6 +1634,19 @@ if (!defined('IS_ADMIN_FLAG')) {
     $sql = $db->bindVars($sql, ':rcId:', $recordCompanyId, 'integer');
     $sql = $db->bindVars($sql, ':languageId:', $languageId, 'integer');
     $db->execute($sql);
+  }
+  /**
+   * function issetorArray
+   *
+   * returns an array[key] or default value if key does not exist
+   *
+   * @param array $array
+   * @param $key
+   * @param null $default
+   * @return mixed
+   */
+  function issetorArray(array $array, $key, $default = null) {
+      return isset($array[$key]) ? $array[$key] : $default;
   }
   /////////////////////////////////////////////
 ////

--- a/testFramework/unittests/phpunit.xml
+++ b/testFramework/unittests/phpunit.xml
@@ -7,6 +7,10 @@
 >
   <testsuites>
 
+      <testsuite name="issetorArray">
+          <file>testIssetorArrayCase.php</file>
+      </testsuite>
+
       <testsuite name="Discount Coupons">
           <file>testDiscountCoupons.php</file>
       </testsuite>

--- a/testFramework/unittests/testIssetorArrayCase.php
+++ b/testFramework/unittests/testIssetorArrayCase.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File contains tests for issetorArray function
+ *
+ * @package tests
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id$
+ */
+require_once('support/zcCatalogTestCase.php');
+/**
+ * Unit Tests for password hashing rules
+ */
+class testIssetorArrayCase extends zcCatalogTestCase
+{
+    public function testIssetor()
+    {
+        $somearray = [];
+        $result = issetorArray($somearray, 'key', 'default');
+        $this->assertTrue($result == 'default');
+        $somearray = array('key'=>'notdefault');
+        $result = issetorArray($somearray, 'key', 'default');
+        $this->assertTrue($result == 'notdefault');
+    }
+}


### PR DESCRIPTION
Some upcoming code in v1.6 needs to test frequently whether an array key exists, and if not set a default value within a ternary structure.
(and we do this is legacy code as well)

As an example

Say we have an array called $somearray, and we want to test that $somearray['key'] exists, and if it doesn't set a default value.

e.g.
if (isset($somearray['key']) {
  return  $somearray['key']
 } else {
  return 'default';
 }
or as a ternary

return (isset($somearray['key']) ? $somearray['key'] ? 'default';

In some cases the above, even when used with a ternary can require a line that extends over the 80 character line limit

using the function rewrites the above as

return issetorArray($somearray, $key, 'default')

reducing the code footprint.

It should be noted that this function mimics the upcoming php7 Null Coalesce Operator https://wiki.php.net/rfc/isset_ternary#vote