### PR TITLE
Refactoring of paginator classes to provide a better interface

### DIFF
--- a/includes/library/zencart/platform/src/Paginator/AbstractScroller.php
+++ b/includes/library/zencart/platform/src/Paginator/AbstractScroller.php
@@ -45,25 +45,22 @@ abstract class AbstractScroller extends \base
      */
     abstract protected function process(array $data, array $params);
 
+
     /**
-     * buildLink method
-     *
-     * @param $params
+     * @param array $params
      * @return string
      */
-    public function buildLink($params)
+    protected function buildLink(array $params)
     {
         $link = zen_href_link($params['cmd'], $params['linkParams']);
         return $link;
     }
 
     /**
-     * getCurrentLinkParams method
-     *
-     * @param $params
+     * @param array $params
      * @return mixed|string
      */
-    public function getRequestParams($params)
+    protected function getRequestParams(array $params)
     {
         $linkParams = zen_get_all_get_params($params['exclude'], $params['linkParams']);
         return $linkParams;

--- a/includes/library/zencart/platform/src/Paginator/AdapterInterface.php
+++ b/includes/library/zencart/platform/src/Paginator/AdapterInterface.php
@@ -13,16 +13,17 @@ namespace ZenCart\Platform\Paginator;
  */
 interface AdapterInterface
 {
-    /**
-     * getResultList method
-     * @return array
-     */
-    public function getResultList($data, $params);
 
     /**
-     * getTotalItemCount method
-     *
-     * @return integer
+     * @param $data
+     * @param array $params
+     * @return mixed
+     */
+    public function getResultList($data, array $params);
+
+    /**
+     * @param $data
+     * @return mixed
      */
     public function getTotalItemCount($data);
 }

--- a/includes/library/zencart/platform/src/Paginator/Paginator.php
+++ b/includes/library/zencart/platform/src/Paginator/Paginator.php
@@ -8,8 +8,6 @@
  */
 namespace ZenCart\Platform\Paginator;
 
-use Instantiator\Exception\InvalidArgumentException;
-
 /**
  * Class Paginator
  * @package ZenCart\Platform\Paginator
@@ -20,29 +18,47 @@ class Paginator extends \base
      * @var mixed
      */
     protected $adapter;
-    
+
     /**
      * @var mixed
      */
     protected $scroller;
+    /**
+     * @var array
+     */
+    protected $scrollerParams = array();
+    /**
+     * @var array
+     */
+    protected $adapterParams = array();
+
+    /**
+     * @var \ZenCart\Platform\Request
+     */
+    protected $request;
 
     /**
      * @param \ZenCart\Platform\Request $request
-     * @param $adapterType
-     * @param $scrollerType
-     * @param $adapterData
-     * @param $adapterParams
-     * @param $scrollerParams
      */
-    public function __construct(\ZenCart\Platform\Request $request, $adapterType, $scrollerType, $adapterData, $adapterParams, $scrollerParams)
+    public function __construct(\ZenCart\Platform\Request $request)
     {
-        $pagingVarName = isset($scrollerParams['pagingVarName']) ? $scrollerParams['pagingVarName'] : 'page';
-        $pagingVarSrc = isset($scrollerParams['pagingVarSrc']) ? $scrollerParams['pagingVarSrc'] : 'get';
-        $currentPage = $request->get($pagingVarName, 1, $pagingVarSrc);
-        $adapterParams['currentPage'] = $currentPage;
-        $scrollerParams['currentPage'] = $currentPage;
-        $this->adapter = $this->buildAdapter($adapterType, $adapterData, $adapterParams);
-        $this->scroller = $this->buildScroller($scrollerType, $this->adapter, $scrollerParams);
+        $this->request = $request;
+    }
+
+    /**
+     * @param $adapterData
+     * @param string $adapterType
+     * @param string $scrollerType
+     */
+    public function doPagination($adapterData, $adapterType = 'QueryFactory', $scrollerType = 'Standard')
+    {
+        $pagingVarName = issetorArray($this->scrollerParams, 'pagingVarName', 'page');
+        $pagingVarSrc = issetorArray($this->scrollerParams, 'pagingVarSrc', 'get');
+        $currentPage = $this->request->get($pagingVarName, 1, $pagingVarSrc);
+        $this->adapterParams['currentPage'] = $currentPage;
+        $this->scrollerParams['currentPage'] = $currentPage;
+        $this->adapter = $this->buildAdapter($adapterType, $adapterData, $this->adapterParams);
+        $this->scroller = $this->buildScroller($scrollerType, $this->adapter, $this->scrollerParams);
     }
 
     /**
@@ -60,7 +76,7 @@ class Paginator extends \base
 
     /**
      * @param $scrollerType
-     * @param array $adapter
+     * @param AdapterInterface $adapter
      * @param array $scrollerParams
      * @return mixed
      */
@@ -85,5 +101,21 @@ class Paginator extends \base
     public function getScroller()
     {
         return $this->scroller;
+    }
+
+    /**
+     * @param $params
+     */
+    public function setScrollerParams(array $params)
+    {
+        $this->scrollerParams = $params;
+    }
+
+    /**
+     * @param $params
+     */
+    public function setAdapterParams(array $params)
+    {
+        $this->adapterParams = $params;
     }
 }

--- a/includes/library/zencart/platform/src/Paginator/Paginator.php
+++ b/includes/library/zencart/platform/src/Paginator/Paginator.php
@@ -62,7 +62,7 @@ class Paginator extends \base
     }
 
     /**
-     * @param $adapterType
+     * @param string $adapterType
      * @param array $adapterData
      * @param array $adapterParams
      * @return mixed
@@ -75,7 +75,7 @@ class Paginator extends \base
     }
 
     /**
-     * @param $scrollerType
+     * @param string $scrollerType
      * @param AdapterInterface $adapter
      * @param array $scrollerParams
      * @return mixed

--- a/includes/library/zencart/platform/src/Paginator/adapters/QueryFactory.php
+++ b/includes/library/zencart/platform/src/Paginator/adapters/QueryFactory.php
@@ -17,15 +17,16 @@ use ZenCart\Platform\Paginator\AbstractAdapter;
  */
 class QueryFactory extends AbstractAdapter implements AdapterInterface
 {
+
     /**
-     * getResultList method
-     *
-     * @return array|mixed
+     * @param $data
+     * @param array $params
+     * @return array
      */
-    public function getResultList($data, $params)
+    public function getResultList($data, array $params)
     {
         $limit = $params['currentItem'] - 1 . ',' . $params['itemsPerPage'];
-        $results = $data['dbConn']->execute($data['sqlQueries']['main'], $limit);
+        $results = $data['dbConn']->execute($data['mainSql'], $limit);
         $resultList = array();
         foreach ($results as $result) {
             $resultList[] = $result;
@@ -34,13 +35,12 @@ class QueryFactory extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-     * getTotalItemCount method
-     *
-     * @return integer
+     * @param $data
+     * @return mixed
      */
     public function getTotalItemCount($data)
     {
-        $result = $data['dbConn']->execute($data['sqlQueries']['count']);
+        $result = $data['dbConn']->execute($data['countSql']);
         return $result->fields['total'];
     }
 } 

--- a/testFramework/unittests/paginator/paginatorAdapterTest.php
+++ b/testFramework/unittests/paginator/paginatorAdapterTest.php
@@ -32,7 +32,7 @@ class testPaginationAdapterCase extends zcPaginatorTestCase
         $db0->fields = array('total'=>'2');
         $db->method('execute')
             ->will($this->onConsecutiveCalls($db0, $db1));
-        $data = array('sqlQueries'=>array('main'=>'', 'count'=>''), 'dbConn'=>$db);
+        $data = array('mainSql'=>'', 'countSql'=>'', 'dbConn'=>$db);
         $parameters = array('pagingVarName'=>'page', 'currentItem'=>1, 'itemsPerPage'=>2);
         $ds = new QueryFactory($data, $parameters);
         $dsr = $ds->getResults();

--- a/testFramework/unittests/paginator/paginatorScrollerTest.php
+++ b/testFramework/unittests/paginator/paginatorScrollerTest.php
@@ -18,7 +18,8 @@ class testPaginationScrollerCase extends zcPaginatorTestCase
     {
         parent::setUp();
         require_once(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'sessions.php');
-        require_once(DIR_FS_ADMIN . DIR_WS_FUNCTIONS . 'html_output.php');
+        require_once(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'html_output.php');
+        define('SEARCH_ENGINE_FRIENDLY_URLS', false);
         require DIR_CATALOG_LIBRARY . 'aura/autoload/src/Loader.php';
         $loader = new \Aura\Autoload\Loader;
         $loader->register();

--- a/testFramework/unittests/paginator/paginatorTest.php
+++ b/testFramework/unittests/paginator/paginatorTest.php
@@ -17,6 +17,9 @@ class testPaginationCase extends zcPaginatorTestCase
     public function setUp()
     {
         parent::setUp();
+        require_once(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'sessions.php');
+        require_once(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'html_output.php');
+        define('SEARCH_ENGINE_FRIENDLY_URLS', false);
         require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'db/mysql/query_factory.php';
         require DIR_CATALOG_LIBRARY . 'aura/autoload/src/Loader.php';
         $loader = new \Aura\Autoload\Loader;
@@ -36,9 +39,12 @@ class testPaginationCase extends zcPaginatorTestCase
         $db->method('execute')
             ->will($this->onConsecutiveCalls($db0, $db1));
 
-        $adapterData = array('dbConn'=>$db, 'sqlQueries'=>array('main'=>'', 'count'=>''));
+        $adapterData = array('dbConn'=>$db, 'mainSql'=>'', 'countSql'=>'');
         $scrollerParams = array('cmd'=>'index');
-        $p = new Paginator($r, 'QueryFactory', 'Standard', $adapterData, array(), $scrollerParams);
+        $p = new Paginator($r);
+        $p->setScrollerParams($scrollerParams);
+        $p->setAdapterParams(array());
+        $p->doPagination($adapterData, 'QueryFactory', 'Standard');
         $a = $p->getAdapter();
         $s = $p->getScroller();
     }

--- a/testFramework/unittests/support/zcPaginatorTestCase.php
+++ b/testFramework/unittests/support/zcPaginatorTestCase.php
@@ -23,7 +23,7 @@ abstract class zcPaginatorTestCase extends PHPUnit_Framework_TestCase
     {
         // Define some pre-requisites
         global $zco_notifier;
-        define('IS_ADMIN_FLAG', 'TRUE');
+        define('IS_ADMIN_FLAG', false);
         if(!defined('TESTCWD')) define('TESTCWD', realpath(__DIR__ . '/../') . '/');
         if(!defined('DIR_FS_CATALOG')) define('DIR_FS_CATALOG', realpath(__DIR__ . '/../../../') . '/');
         if(!defined('DIR_FS_INCLUDES')) define('DIR_FS_INCLUDES', DIR_FS_CATALOG . 'includes/');


### PR DESCRIPTION
When testing the paginator classes with real world code (listingbox stuff), I realised that the public interface wasn't good enough.
The constructor required parameters that were not always required (e.g. would be better using method injection)
I've updated code to use the new issetorArray function.
I've updated tests based on the new public interface, as well as updating some doc block stuff