### PR TITLE
Fix typo in method call

### DIFF
--- a/includes/modules/payment/paypal/paypal_curl.php
+++ b/includes/modules/payment/paypal/paypal_curl.php
@@ -3,9 +3,9 @@
  * paypal_curl.php communications class for PayPal Express Checkout / Website Payments Pro / Payflow Pro payment methods
  *
  * @package paymentMethod
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Tue Aug 28 14:21:34 2012 -0400 Modified in v1.6.0 $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.6.0 $
  */
 
 /**

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -3,7 +3,7 @@
  * paypaldp.php payment module class for Paypal Payments Pro (aka Website Payments Pro)
  *
  * @package paymentMethod
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2005 CardinalCommerce
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -2153,7 +2153,7 @@ class paypaldp extends base {
     // determine the appropriate product code for submission
     $prodCode = FALSE;
     if (isset($_SESSION['cart'])) {
-      if ($_SESSION['cart']->get_cart_type == 'virtual') {
+      if ($_SESSION['cart']->get_content_type == 'virtual') {
         $prodCode = 'DIG';
       } else {
         $prodCode = 'PHY';


### PR DESCRIPTION
Fix typo in method call, as identified by @lat9 in http://www.zen-cart.com/showthread.php?208310-paypaldp-php-Invalid-class-variable