### PR TITLE
Replace phpBB with hooks for external "forum" systems - Closes #272

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -37,7 +37,6 @@ filter:
         - 'includes/classes/class.phpmailer.php'
         - 'includes/classes/class.smtp.php'
         - 'includes/classes/http_client.php'
-        - 'includes/classes/class.phpbb.php'
         - 'includes/library/aura/*'
         - 'includes/modules/debug_blocks/*'
         - 'includes/modules/payment/linkpoint_api/*'

--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -6,7 +6,7 @@
  * @package initSystem
  * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id:
+ * @version GIT: $Id: Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
  die('Illegal Access');
@@ -58,8 +58,6 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
                                 'loadFile'=>'cache.php');
   $autoLoadConfig[0][] = array('autoType'=>'class',
                                 'loadFile'=>'sniffer.php');
-  $autoLoadConfig[0][] = array('autoType'=>'class',
-                                'loadFile'=>'class.phpbb.php');
   $autoLoadConfig[0][] = array('autoType'=>'class',
                                 'loadFile'=>'shopping_cart.php');
   $autoLoadConfig[0][] = array('autoType'=>'class',
@@ -178,7 +176,6 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
  * $sniffer = new sniffer();
  * require('includes/init_includes/init_gzip.php');
  * require('includes/init_includes/init_sefu.php');
- * $phpBB = new phpBB();
  */
   $autoLoadConfig[50][] = array('autoType'=>'classInstantiate',
                                 'className'=>'sniffer',
@@ -187,9 +184,6 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
                                 'loadFile'=> 'init_gzip.php');
   $autoLoadConfig[50][] = array('autoType'=>'init_script',
                                 'loadFile'=> 'init_sefu.php');
-  $autoLoadConfig[50][] = array('autoType'=>'classInstantiate',
-                                'className'=>'phpBB',
-                                'objectName'=>'phpBB');
 /**
  * Breakpoint 60.
  *

--- a/includes/auto_loaders/paypal_ipn.core.php
+++ b/includes/auto_loaders/paypal_ipn.core.php
@@ -75,7 +75,6 @@ if (!defined('IS_ADMIN_FLAG')) {
  *
  * $sniffer = new sniffer();
  * require('includes/init_includes/init_sefu.php');
- * $phpBB = new phpBB();
  */
   $autoLoadConfig[50][] = array('autoType'=>'classInstantiate',
                                 'className'=>'sniffer',

--- a/includes/classes/sniffer.php
+++ b/includes/classes/sniffer.php
@@ -24,7 +24,6 @@ class sniffer extends base {
     $this->php = Array();
     $this->server = Array();
     $this->database = Array();
-    $this->phpBB = Array();
   }
 
   function table_exists($table_name) {
@@ -72,4 +71,3 @@ class sniffer extends base {
     return false;
   }
 }
-?>

--- a/includes/filenames.php
+++ b/includes/filenames.php
@@ -4,10 +4,10 @@
  * Defines the filenames used in the project
  *
  * @package general
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: filenames.php 19690 2011-10-04 16:41:45Z drbyte $
+ * @version $Id: filenames.php  Modified in v1.6.0 $
  * @version $Id: Integrated COWOA v2.2 - 2007 - 2012
  * @private
  */
@@ -192,4 +192,3 @@ define('FILENAME_PRODUCTS_DISCOUNT_PRICES','products_discount_prices.php');
 define('FILENAME_SPECIALS_INDEX', 'specials_index.php');
 define('FILENAME_UPCOMING_PRODUCTS', 'upcoming_products.php');
 
-define('FILENAME_BB_INDEX', 'index.php'); // phpBB main index filename

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package languageDefines
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: english.php 19690 2011-10-04 16:41:45Z drbyte $
+ * @version $Id: english.php  Modified in v1.6.0 $
  */
 
   define('CONNECTION_TYPE_UNKNOWN', '\'%s\' is not a valid connection type for generating URLs' . PHP_EOL . '%s' . PHP_EOL);
@@ -100,7 +100,6 @@
   define('BOX_INFORMATION_CONDITIONS', 'Conditions of Use');
   define('BOX_INFORMATION_SHIPPING', 'Shipping &amp; Returns');
   define('BOX_INFORMATION_CONTACT', 'Contact Us');
-  define('BOX_BBINDEX', 'Forum');
   define('BOX_INFORMATION_UNSUBSCRIBE', 'Newsletter Unsubscribe');
 
   define('BOX_INFORMATION_SITE_MAP', 'Site Map');

--- a/includes/modules/create_account.php
+++ b/includes/modules/create_account.php
@@ -158,7 +158,8 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
   }
 
   $nick_error = false;
-  $zco_notifier->notify('NOTIFY_NICK_CHECK_FOR_MIN_LENGTH', $nick, $nick_error, ENTRY_NICK_MIN_LENGTH);
+  $nick_length_min = ENTRY_NICK_MIN_LENGTH;
+  $zco_notifier->notify('NOTIFY_NICK_CHECK_FOR_MIN_LENGTH', $nick, $nick_error, $nick_length_min);
   if ($nick_error) $error = true;
   $zco_notifier->notify('NOTIFY_NICK_CHECK_FOR_DUPLICATE', $nick, $nick_error);
   if ($nick_error) $error = true;

--- a/includes/modules/pages/account_password/header_php.php
+++ b/includes/modules/pages/account_password/header_php.php
@@ -3,10 +3,10 @@
  * Header code file for the Account Password page
  *
  * @package page
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: header_php.php 18697 2011-05-04 14:35:20Z wilt $
+ * @version $Id: header_php.php  Modified in v1.6.0 $
  */
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_PASSWORD');
@@ -44,7 +44,6 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
     $check_customer = $db->Execute($check_customer_query);
 
     if (zen_validate_password($password_current, $check_customer->fields['customers_password'])) {
-      $nickname = $check_customer->fields['customers_nick'];
       zcPassword::getInstance(PHP_VERSION)->updateLoggedInCustomerPassword($password_new, $_SESSION['customer_id']);
 
       $sql = "UPDATE " . TABLE_CUSTOMERS_INFO . "
@@ -54,11 +53,8 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
       $sql = $db->bindVars($sql, ':customersID',$_SESSION['customer_id'], 'integer');
       $db->Execute($sql);
 
-        if ($phpBB->phpBB['installed'] == true) {
-          if (zen_not_null($nickname) && $nickname != '') {
-            $phpBB->phpbb_change_password($nickname, $password_new);
-          }
-        }
+      // handle 3rd-party integrations
+      $zco_notifier->notify('NOTIFY_HEADER_ACCOUNT_PASSWORD_CHANGED', $_SESSION['customer_id'], $password_new, $check_customer->fields['customers_nick']);
 
       $messageStack->add_session('account', SUCCESS_PASSWORD_UPDATED, 'success');
 

--- a/includes/modules/sideboxes/information.php
+++ b/includes/modules/sideboxes/information.php
@@ -3,10 +3,10 @@
  * information sidebox - displays list of general info links, as defined in this file
  *
  * @package templateSystem
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: information.php 4132 2006-08-14 00:36:39Z drbyte $
+ * @version $Id: information.php  Modified in v1.6.0 $
  */
 
   unset($information);
@@ -24,11 +24,9 @@
     $information[] = '<a href="' . zen_href_link(FILENAME_CONTACT_US, '', 'SSL') . '">' . BOX_INFORMATION_CONTACT . '</a>';
   }
 
-// Forum (phpBB) link:
-  if ( (isset($phpBB->phpBB['db_installed_config']) && $phpBB->phpBB['db_installed_config']) && (isset($phpBB->phpBB['files_installed']) && $phpBB->phpBB['files_installed'])  && (PHPBB_LINKS_ENABLED=='true')) {
-    $information[] = '<a href="' . zen_href_link($phpBB->phpBB['phpbb_url'] . FILENAME_BB_INDEX, '', 'NONSSL', false, '', true) . '" target="_blank">' . BOX_BBINDEX . '</a>';
-// or: $phpBB->phpBB['phpbb_url'] . FILENAME_BB_INDEX
-// or: str_replace(str_replace(DIR_WS_CATALOG, '', DIR_FS_CATALOG), '', DIR_WS_PHPBB)
+// forum/bb link:
+  if (!empty($external_bb_url) && !empty($external_bb_text)) {
+    $information[] = '<a href="' . $external_bb_url . '" target="_blank">' . $external_bb_text . '</a>';
   }
 
   if (DEFINE_SITE_MAP_STATUS <= 1) {

--- a/includes/templates/template_default/templates/tpl_modules_create_account.php
+++ b/includes/templates/template_default/templates/tpl_modules_create_account.php
@@ -6,10 +6,10 @@
  * Displays Create Account form.
  *
  * @package templateSystem
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Sun Aug 19 09:47:29 2012 -0400 Modified in v1.5.1 $
+ * @version GIT: $Id:  Modified in v1.6.0 $
  */
 ?>
 
@@ -153,7 +153,7 @@
 <br class="clearBoth" />
 
 <?php
-  if ($phpBB->phpBB['installed'] == true) {
+  if ($display_nick_field == true) {
 ?>
 <label class="inputLabel" for="nickname"><?php echo ENTRY_NICK; ?></label>
 <?php echo zen_draw_input_field('nick','','id="nickname"') . (zen_not_null(ENTRY_NICK_TEXT) ? '<span class="alert">' . ENTRY_NICK_TEXT . '</span>': ''); ?>

--- a/includes/templates/template_default/templates/tpl_site_map_default.php
+++ b/includes/templates/template_default/templates/tpl_site_map_default.php
@@ -6,10 +6,10 @@
  * Displays site-map and some hard-coded navigation components
  *
  * @package templateSystem
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: tpl_site_map_default.php 4340 2006-09-02 04:54:53Z drbyte $
+ * @version $Id: tpl_site_map_default.php  Modified in v1.6.0 $
  */
 ?>
 <div class="centerColumn" id="siteMap">
@@ -58,8 +58,8 @@
 <?php if (DEFINE_CONTACT_US_STATUS <= '1') { ?>
             <li><?php echo '<a href="' . zen_href_link(FILENAME_CONTACT_US, '', 'SSL') . '">' . BOX_INFORMATION_CONTACT . '</a>'; ?></li>
 <?php } ?>
-<?php if ( (isset($phpBB->phpBB['db_installed_config']) && $phpBB->phpBB['db_installed_config']) && (isset($phpBB->phpBB['files_installed']) && $phpBB->phpBB['files_installed'])  && (PHPBB_LINKS_ENABLED=='true')) { ?>
-            <li><?php echo '<a href="' . zen_href_link($phpBB->phpBB['phpbb_url'] . FILENAME_BB_INDEX, '', 'NONSSL', false, '', true) . '" target="_blank">' . BOX_BBINDEX . '</a>'; ?></li>
+<?php if (!empty($external_bb_url) && !empty($external_bb_text)) { ?>
+            <li><?php echo '<a href="' . $external_bb_url . '" target="_blank">' . $external_bb_text . '</a>'; ?></li>
 <?php } ?>
 <?php if (MODULE_ORDER_TOTAL_GV_STATUS == 'true') { ?>
             <li><?php echo '<a href="' . zen_href_link(FILENAME_GV_FAQ) . '">' . BOX_INFORMATION_GV . '</a>'; ?></li>

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -2361,8 +2361,6 @@ INSERT INTO configuration (configuration_title, configuration_key, configuration
 
 
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('HTML Editor', 'HTML_EDITOR_PREFERENCE', 'NONE', 'Please select the HTML/Rich-Text editor you wish to use for composing Admin-related emails, newsletters, and product descriptions', '1', '110', 'zen_cfg_pull_down_htmleditors(', now());
-#phpbb
-INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Enable phpBB linkage?', 'PHPBB_LINKS_ENABLED', 'false', 'Should Zen Cart synchronize new account information to your (already-installed) phpBB forum?', '1', '120', 'zen_cfg_select_option(array(\'true\', \'false\'),', now());
 
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Show Category Counts - Admin', 'SHOW_COUNTS_ADMIN', 'true', 'Show Category Counts in Admin?', '1', '19', 'zen_cfg_select_option(array(\'true\', \'false\'), ', now());
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Show linked status for categories', 'SHOW_CATEGORY_PRODUCTS_LINKED_STATUS', 'true', 'Show Category products linked status?', '1', '19', 'zen_cfg_select_option(array(\'true\', \'false\'), ', now());

--- a/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
@@ -74,6 +74,10 @@ INSERT INTO configuration (configuration_title, configuration_key, configuration
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Categories with Inactive Products Status', 'CATEGORIES_PRODUCTS_INACTIVE_HIDE', '0', 'Hide Categories with Inactive Products?<br />0= off<br />1= on', 19, 30, 'zen_cfg_select_option(array(\'0\', \'1\'), ', now());
 
 UPDATE configuration set configuration_group_id = 6 where configuration_key in ('PRODUCTS_OPTIONS_TYPE_SELECT', 'UPLOAD_PREFIX', 'TEXT_PREFIX');
+
+DELETE FROM configuration where configuration_key = 'PHPBB_LINKS_ENABLED' && configuration_value != 'true';
+
+
 UPDATE countries set address_format_id = 7 where countries_iso_code_3 = 'AUS';
 UPDATE countries set address_format_id = 5 where countries_iso_code_3 IN ('BEL', 'NLD', 'SWE');
 


### PR DESCRIPTION
Notifier hooks have been added so that all former phpBB integration can be handled with custom observer class methods.

Integration note: there are a couple places where global variables like `$external_bb_text` are referenced, but no specific notifier hook is called to set them. This is because the code that 'uses' those variables is already in global scope, and therefore from within your observer class you can simply declare those variables as `global`s, and assign them a value there. Since this is still procedural code, in an observer class it is probably appropriate to do this in `__construct`.

Most other variables are set by simply letting observer class functions set the desired values and pass-by-reference (ie: params 2 - 9 for observer `update` triggers)

ALSO NOTE:

> An advanced observer class feature is to create several `update` functions, named according to the specific notifier hook you want them to respond to. So, responding to NOTIFY_NICK_SET_TEMPLATE_FLAG could be done with its own function:

```php
function updateNotifyNickSetTemplateFlag(&$class, $eventID, $none, $display_nick_field) {
  if ($this->myBbSystemIsEnabled) $display_nick_field = true;
}
```