### PR TITLE
Strip out "number_of_uploads" param when done with it

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1937,8 +1937,13 @@ class shoppingCart extends base {
                 $real_ids[TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i]] = $_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i];
               }
             }
+
+            // remove helper param from URI of the upcoming redirect
+            $parameters[] = 'number_of_uploads';
+            unset($_GET['number_of_uploads']);
           }
 
+          // do the actual add to cart
           $this->add_cart($_POST['products_id'], $this->get_quantity(zen_get_uprid($_POST['products_id'], $real_ids))+($new_qty), $real_ids);
           // iii 030813 end of changes.
         } // eof: set error message


### PR DESCRIPTION
In places such as add-to-cart, an extra GET param `number_of_uploads` gets left on the URI, but serves no purpose since it's used *before* getting to the shopping-cart page.