### PR TITLE
Disable code-coverage reporting in TravisCI (in favor of Scrutinizer)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
 
 after_script:
   #- vendor/bin/phpcs --standard=PSR2 includes/ testFramework/
-  - php vendor/bin/coveralls
+  #- php vendor/bin/coveralls
   #- vendor/bin/phpmd includes/ text cleancode,codesize,controversial,design,naming,unusedcode
 
 notifications:

--- a/testFramework/unittests/phpunit.xml
+++ b/testFramework/unittests/phpunit.xml
@@ -47,26 +47,6 @@
 
   </testsuites>
 
-  <logging>
-    <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"
-      lowUpperBound="50" highLowerBound="80" />
-    <log type="coverage-clover" target="build/logs/clover.xml" />
-  </logging>
-
-  <filter>
-    <blacklist>
-      <directory suffix=".php">vendor</directory>
-      <directory suffix=".php">admin/includes/local</directory>
-      <directory suffix=".php">includes/local</directory>
-      <directory suffix=".php">testFramework</directory>
-      <directory suffix=".php">build</directory>
-      <directory suffix=".php">zc_install</directory>
-    </blacklist>
-    <whitelist processUncoveredFilesFromWhitelist="false">
-      <directory suffix=".php">admin/includes</directory>
-      <directory suffix=".php">includes</directory>
-    </whitelist>
-  </filter>
 
   <php>
     <const name="PHPUNIT_TESTSUITE" value="true" />


### PR DESCRIPTION
This will speed up tests considerably, and Scrutinizer can run the coverage reports separately.