### PR TITLE
Fix errors caused by method renaming in tableBlock class

### DIFF
--- a/admin/includes/classes/box.php
+++ b/admin/includes/classes/box.php
@@ -24,7 +24,7 @@ if (!defined('IS_ADMIN_FLAG')) {
   echo $box->infoBox($heading, $contents);
 */
 
-  class box extends tableBlock {
+  class box extends boxTableBlock {
     function __construct() {
       $this->heading = array();
       $this->contents = array();

--- a/admin/includes/classes/message_stack.php
+++ b/admin/includes/classes/message_stack.php
@@ -19,7 +19,7 @@ if (!defined('IS_ADMIN_FLAG')) {
   if ($messageStack->size > 0) echo $messageStack->output();
 */
 
-  class messageStack extends tableBlock {
+  class messageStack extends boxTableBlock {
     var $size = 0;
 
     function __construct() {

--- a/admin/includes/classes/table_block.php
+++ b/admin/includes/classes/table_block.php
@@ -7,7 +7,7 @@
  * @version $Id: table_block.php 1969 2005-09-13 06:57:21Z drbyte  Modified in v1.6.0 $
  */
 
-  class tableBlock {
+  class boxTableBlock {
     var $table_border = '0';
     var $table_width = '100%';
     var $table_cellspacing = '0';
@@ -16,7 +16,7 @@
     var $table_row_parameters = '';
     var $table_data_parameters = '';
 
-    function __construct($contents) {
+    function tableBlock($contents) {
       $tableBox_string = '';
 
       $form_set = false;


### PR DESCRIPTION
e.g.  Call to undefined method messageStack::tableBlock()