### PR TITLE
Fix objectInfo class

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: banner_manager.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -255,9 +255,9 @@ function popupImageWindow(url) {
                                      from " . TABLE_BANNERS . "
                                      where banners_id = '" . (int)$bID . "'");
 
-      $bInfo->objectInfo($banner->fields);
+      $bInfo->updateObjectInfo($banner->fields);
     } elseif (zen_not_null($_POST)) {
-      $bInfo->objectInfo($_POST);
+      $bInfo->updateObjectInfo($_POST);
     }
 
     if (!isset($bInfo->status)) $bInfo->status = '1';

--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version GIT: $Id: Author: DrByte  Jun 30 2014 Modified in v1.5.4 $
@@ -252,9 +252,9 @@ require('includes/admin_html_head.php');
 
       $page_query = "select * from " . TABLE_EZPAGES . " where pages_id = '" . (int)$_GET['ezID'] . "'";
       $page = $db->Execute($page_query);
-      $ezInfo->objectInfo($page->fields);
+      $ezInfo->updateObjectInfo($page->fields);
     } elseif (zen_not_null($_POST)) {
-      $ezInfo->objectInfo($_POST);
+      $ezInfo->updateObjectInfo($_POST);
     }
 
 // set all status settings and switches

--- a/admin/includes/classes/object_info.php
+++ b/admin/includes/classes/object_info.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package admin
  * @copyright Copyright 2003-2015 Zen Cart Development Team
@@ -7,15 +8,33 @@
  * @version $Id:  Modified in v1.6.0 $
  */
 
+/**
+ * Class objectInfo
+ */
 class objectInfo
 {
+    /**
+     * @var
+     */
+    protected $key;
 
-  function __construct($object_array)
-  {
-    if (!is_array($object_array)) return;
-    reset($object_array);
-    while (list($key, $value) = each($object_array)) {
-      $this->$key = zen_db_prepare_input($value);
+    /**
+     * @param $object_array
+     */
+    function __construct($object_array)
+    {
+        $this->updateObjectInfo($object_array);
     }
-  }
+
+    /**
+     * @param $object_array
+     */
+    function updateObjectInfo($object_array)
+    {
+        if (!is_array($object_array)) return;
+        reset($object_array);
+        while (list($key, $value) = each($object_array)) {
+            $this->$key = zen_db_prepare_input($value);
+        }
+    }
 }

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -63,9 +63,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and p.products_id = pd.products_id
                               and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $products_name = $_POST['products_name'];
       $products_description = $_POST['products_description'];
       $products_url = $_POST['products_url'];

--- a/admin/includes/modules/document_general/collect_info_metatags.php
+++ b/admin/includes/modules/document_general/collect_info_metatags.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info_metatags.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -50,9 +50,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and mtpd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
     }
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $metatags_title = $_POST['metatags_title'];
       $metatags_keywords = $_POST['metatags_keywords'];
       $metatags_description = $_POST['metatags_description'];

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -63,9 +63,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and p.products_id = pd.products_id
                               and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $products_name = $_POST['products_name'];
       $products_description = $_POST['products_description'];
       $products_url = $_POST['products_url'];

--- a/admin/includes/modules/document_product/collect_info_metatags.php
+++ b/admin/includes/modules/document_product/collect_info_metatags.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info_metatags.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -50,9 +50,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and mtpd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
     }
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $metatags_title = $_POST['metatags_title'];
       $metatags_keywords = $_POST['metatags_keywords'];
       $metatags_description = $_POST['metatags_description'];

--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -63,9 +63,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and p.products_id = pd.products_id
                               and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $products_name = $_POST['products_name'];
       $products_description = $_POST['products_description'];
       $products_url = $_POST['products_url'];

--- a/admin/includes/modules/product/collect_info_metatags.php
+++ b/admin/includes/modules/product/collect_info_metatags.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info_metatags.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -50,9 +50,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and mtpd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
     }
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $metatags_title = $_POST['metatags_title'];
       $metatags_keywords = $_POST['metatags_keywords'];
       $metatags_description = $_POST['metatags_description'];

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -63,9 +63,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and p.products_id = pd.products_id
                               and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $products_name = $_POST['products_name'];
       $products_description = $_POST['products_description'];
       $products_url = $_POST['products_url'];

--- a/admin/includes/modules/product_free_shipping/collect_info_metatags.php
+++ b/admin/includes/modules/product_free_shipping/collect_info_metatags.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info_metatags.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -50,9 +50,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and mtpd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
     }
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $metatags_title = $_POST['metatags_title'];
       $metatags_keywords = $_POST['metatags_keywords'];
       $metatags_description = $_POST['metatags_description'];

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -64,9 +64,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and p.products_id = pd.products_id and p.products_id = pe.products_id
                               and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $products_name = $_POST['products_name'];
       $products_description = $_POST['products_description'];
       $products_url = $_POST['products_url'];

--- a/admin/includes/modules/product_music/collect_info_metatags.php
+++ b/admin/includes/modules/product_music/collect_info_metatags.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: collect_info_metatags.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -50,9 +50,9 @@ if (!defined('IS_ADMIN_FLAG')) {
                               and mtpd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
     }
 
-      $pInfo->objectInfo($product->fields);
+      $pInfo->updateObjectInfo($product->fields);
     } elseif (zen_not_null($_POST)) {
-      $pInfo->objectInfo($_POST);
+      $pInfo->updateObjectInfo($_POST);
       $metatags_title = $_POST['metatags_title'];
       $metatags_keywords = $_POST['metatags_keywords'];
       $metatags_description = $_POST['metatags_description'];

--- a/admin/newsletters.php
+++ b/admin/newsletters.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: newsletters.php 19330 2011-08-07 06:32:56Z drbyte $
@@ -181,9 +181,9 @@ check_select('audience_selected','',"<?php echo ERROR_PLEASE_SELECT_AUDIENCE; ?>
                                   from " . TABLE_NEWSLETTERS . "
                                   where newsletters_id = '" . (int)$nID . "'");
 
-      $nInfo->objectInfo($newsletter->fields);
+      $nInfo->updateObjectInfo($newsletter->fields);
     } elseif ($_POST) {
-      $nInfo->objectInfo($_POST);
+      $nInfo->updateObjectInfo($_POST);
     }
 
     $file_extension = substr($PHP_SELF, strrpos($PHP_SELF, '.'));


### PR DESCRIPTION
This is part of the php7 updates.
The objectInfo class original constructor was also being called as a method in of itself
So the original refactor (renaming the old php 5.3 constructor) broke a lot of code as there was no longer an objectInfo method.