### PR TITLE
Why query all fields when only products_attributes_id is needed

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -787,7 +787,7 @@ class shoppingCart extends base {
         // adjust for downloads
             // adjust products price
               $check_attribute = $attribute_price->fields['products_attributes_id'];
-              $sql = "select *
+              $sql = "select products_attributes_id
                       from " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . "
                       where products_attributes_id = '" . $check_attribute . "'";
               $check_download = $db->Execute($sql);


### PR DESCRIPTION
Here only a simple check is done for the existence of a record. I do not think all fields are needed to do that

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/390)
<!-- Reviewable:end -->
