### PR TITLE
Fix bug from v154 which incremented language_id incorrectly

### DIFF
--- a/admin/languages.php
+++ b/admin/languages.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Jun 30 2014 Modified in v1.5.4 $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.6.0 $
  */
 
   require('includes/application_top.php');
@@ -27,9 +27,9 @@
                         values ('" . zen_db_input($name) . "', '" . zen_db_input($code) . "',
                                 '" . zen_db_input($image) . "', '" . zen_db_input($directory) . "',
                                 '" . zen_db_input($sort_order) . "')");
-          zen_record_admin_activity('Language [' . $code . '] added', 'info');
-
           $insert_id = $db->Insert_ID();
+
+          zen_record_admin_activity('Language [' . $code . '] added', 'info');
 
           // set default, if selected
           if (isset($_POST['default']) && ($_POST['default'] == 'on')) {


### PR DESCRIPTION
Fix bug from v154 (CHANGE-709) which incremented language_id incorrectly

Ref: http://www.zen-cart.com/showthread.php?215842-Insertion-of-an-additional-language-does-not-copy-existing-category-product-texts&p=1269562#post1269562