### PR TITLE
Add related-context lines to results in dev toolkit

### DIFF
--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -9,6 +9,8 @@
 
   require('includes/application_top.php');
 
+  $default_context_lines = 0;
+
   $configuration_key_lookup = (isset($_POST['configuration_key'])) ? zen_db_prepare_input($_POST['configuration_key'], false) : '';
   if (isset($_GET['configuration_key_lookup']) && $_GET['configuration_key_lookup'] != '') {
     $configuration_key_lookup = zen_db_prepare_input(strtoupper($_GET['configuration_key_lookup']), false);
@@ -189,7 +191,7 @@
             $cnt_found++;
             $line_numpos = $line_num + 1;
 
-            for($j=$max_context_lines_before; $j > 0; $j--) {
+            for($j=min($max_context_lines_before, $line_num); $j > 0; $j--) {
               $show_file .= "<br />Line #<strong>" . ($line_numpos-$j) . "</strong> : ";
               $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($lines[($line_num-$j)], ENT_QUOTES, CHARSET);
             }
@@ -200,7 +202,7 @@
             $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($line, ENT_QUOTES, CHARSET);
             if ($max_context_lines_before > 0) $show_file .= '</strong>';
 
-            for($j=1; $j < $max_context_lines_after+1; $j++) {
+            for($j=1, $m = min($max_context_lines_after, sizeof($lines)-$line_num); $j < $m+1; $j++) {
               $show_file .= "<br>Line #<strong>" . ($line_numpos+$j) . "</strong> : ";
               $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($lines[($line_num+$j)], ENT_QUOTES, CHARSET);
             }
@@ -220,7 +222,8 @@
         echo $show_file . '<table><tr><td>&nbsp;</td></tr></table>';
       } // show file
     }
-    echo '<table border="0" width="100%" cellspacing="2" cellpadding="1" align="center"><tr class="infoBoxContent"><td class="dataTableHeadingContent">' . TEXT_INFO_MATCHES_FOUND . $cnt_found . '</td></tr></table>';
+    echo '<table border="0" width="100%" cellspacing="2" cellpadding="1" align="center"><tr class="infoBoxContent"><td class="dataTableHeadingContent">' . TEXT_INFO_MATCHES_FOUND . $cnt_found . ' --- ' . TEXT_INFO_SEARCHING . sizeof($directory_array) . TEXT_INFO_FILES_FOR . zen_output_string_protected($configuration_key_lookup) . '</td></tr></table>';
+
   } // zen_display_files
 
   /* ==================================================================== */
@@ -936,7 +939,7 @@ if ($action == 'search_config_keys') {
 
                 echo '<strong>' . TEXT_ALL_FILESTYPE_LOOKUPS . '</strong>' . '<br />' . zen_draw_pull_down_menu('zv_filestype', $za_lookup_filetype, 1);
                 echo '<label for="locate-cs">' . TEXT_CASE_SENSITIVE . ' </label>' . zen_draw_checkbox_field('case_sensitive', true, false, '', 'id="locate-cs"');
-                echo '<label for="context_lines"> ' . TEXT_CONTEXT_LINES . ' </label>' . zen_draw_input_field('context_lines', '3', 'id="context_lines" size="1"');
+                echo '<label for="context_lines"> ' . TEXT_CONTEXT_LINES . ' </label>' . zen_draw_input_field('context_lines', (int)$default_context_lines, 'id="context_lines" size="1"');
               ?>
             </td>
             <td class="main" align="right" valign="bottom"><?php echo zen_image_submit('button_search.gif', IMAGE_SEARCH); ?></td>

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -203,7 +203,7 @@
             $show_file .= '<br>Line #<span class="dtk-linenum">' . number_pad_with_spaces($line_numpos, $padding_length) . '</span> : ';
 
             if ($max_context_lines_before > 0) $show_file .= '<strong>';
-            $show_file .= '<span class="dtk-foundline">';
+            $show_file .= '<span class="dtk-foundline' . ($max_context_lines_before > 0 ? '-multi' : '') . '">';
             $show_file .= cleanup_dtk_output_text($line, $configuration_key_lookup, $case_sensitive);
             $show_file .= '</span>';
             if ($max_context_lines_before > 0) $show_file .= '</strong>';
@@ -236,8 +236,12 @@
 
 
   /**
+   * Strip out dangerous content, run htmlspecialchars, and insert highlighting of "found" text
+   *
    * @param string $input
    * @param string $highlight
+   * @param boolean $case_sensitive
+   * @return string
    */
   function cleanup_dtk_output_text($input = '', $highlight = '', $case_sensitive = false)
   {
@@ -264,6 +268,13 @@
     return $input;
   }
 
+  /**
+   * Left-pad input "number" string with spaces
+   *
+   * @param string $number The number string to pad
+   * @param int $n The number of padding characters to accommodate
+   * @return string
+   */
   function number_pad_with_spaces($number, $n = 0) {
     return str_replace(' ', '&nbsp;', str_pad((int)$number, $n, ' ', STR_PAD_LEFT));
   }

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -174,6 +174,7 @@
         // loop through the array, show line and line numbers
         $cnt_lines = 0;
         foreach ($lines as $line_num => $line) {
+          $padding_length = strlen(strval(sizeof($lines)));
           $cnt_lines++;
           if (isset($_POST['case_sensitive']) && $_POST['case_sensitive']) {
             $check_case = strstr($line, $configuration_key_lookup);
@@ -192,19 +193,25 @@
             $line_numpos = $line_num + 1;
 
             for($j=min($max_context_lines_before, $line_num); $j > 0; $j--) {
-              $show_file .= "<br />Line #<strong>" . ($line_numpos-$j) . "</strong> : ";
-              $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($lines[($line_num-$j)], ENT_QUOTES, CHARSET);
+              $show_file .= '<br>Line #<span class="dtk-linenum">' . number_pad_with_spaces($line_numpos-$j, $padding_length) . '</span> : ';
+              $show_file .= '<span class="dtk-contextline">';
+              $show_file .= cleanup_dtk_output_text($lines[($line_num-$j)]);
+              $show_file .= '</span>';
             }
 
-            //prevent db pwd from being displayed, for sake of security
-            $show_file .= "<br>Line #<strong>{$line_numpos}</strong> : " ;
+            $show_file .= '<br>Line #<span class="dtk-linenum">' . number_pad_with_spaces($line_numpos, $padding_length) . '</span> : ';
+
             if ($max_context_lines_before > 0) $show_file .= '<strong>';
-            $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($line, ENT_QUOTES, CHARSET);
+            $show_file .= '<span class="dtk-foundline">';
+            $show_file .= cleanup_dtk_output_text($line);
+            $show_file .= '</span>';
             if ($max_context_lines_before > 0) $show_file .= '</strong>';
 
             for($j=1, $m = min($max_context_lines_after, sizeof($lines)-$line_num); $j < $m+1; $j++) {
-              $show_file .= "<br>Line #<strong>" . ($line_numpos+$j) . "</strong> : ";
-              $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($lines[($line_num+$j)], ENT_QUOTES, CHARSET);
+              $show_file .= '<br>Line #<span class="dtk-linenum">' . number_pad_with_spaces($line_numpos+$j, $padding_length) . '</span> : ';
+              $show_file .= '<span class="dtk-contextline">';
+              $show_file .= cleanup_dtk_output_text($lines[($line_num+$j)]);
+              $show_file .= '</span>';
             }
             $show_file .= "<br>\n";
           } else {
@@ -225,6 +232,28 @@
     echo '<table border="0" width="100%" cellspacing="2" cellpadding="1" align="center"><tr class="infoBoxContent"><td class="dataTableHeadingContent">' . TEXT_INFO_MATCHES_FOUND . $cnt_found . ' --- ' . TEXT_INFO_SEARCHING . sizeof($directory_array) . TEXT_INFO_FILES_FOR . zen_output_string_protected($configuration_key_lookup) . '</td></tr></table>';
 
   } // zen_display_files
+
+
+  /**
+   * @param string $input
+   * @param string $highlight
+   */
+  function cleanup_dtk_output_text($input, $highlight)
+  {
+    //prevent db pwd from being displayed, for sake of security
+    $input = (substr_count($input,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : $input;
+    // highlight the selected text
+    $input = str_replace($highlight, '<span class="dtk-highlite">' . $highlight . '</span>', $input);
+    // sanitize output
+    $input = htmlspecialchars($input, ENT_QUOTES, CHARSET);
+    // keep original "spaces" (doesn't account for tabs)
+    $input = str_replace(' ', '&nbsp;', $input);
+    return $input;
+  }
+
+  function number_pad_with_spaces($number, $n) {
+    return str_replace(' ', '&nbsp;', str_pad((int)$number, $n, ' ', STR_PAD_LEFT));
+  }
 
   /* ==================================================================== */
 
@@ -585,6 +614,7 @@
 
 require('includes/admin_html_head.php');
 ?>
+<link rel="stylesheet" type="text/css" href="includes/template/css/developers_tool_kit.css" />
 <style>.dataTableGroupChange {border-top: 2px solid black;}</style>
 </head>
 <body>

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Tue Jun 3 2014 -0500 Modified in v1.5.3 $
+ * @version GIT: $Id: developers_tool_kit.php Author: DrByte  Modified in v1.6.0 $
  */
 
   require('includes/application_top.php');
@@ -53,6 +53,9 @@
   function zen_display_files($include_root = false, $filetypesincluded = 1) {
     global $check_directory, $found, $configuration_key_lookup;
     global $db;
+    $max_context_lines_before = 3;
+    $max_context_lines_after = 3;
+
     $directory_array = array();
     for ($i = 0, $n = sizeof($check_directory); $i < $n; $i++) {
 //echo 'I SEE ' . $check_directory[$i] . '<br>';
@@ -186,10 +189,23 @@
             $found = 'true';
             $cnt_found++;
             $line_numpos = $line_num + 1;
-            $show_file .= "<br />Line #<strong>{$line_numpos}</strong> : " ;
+
+            for($j=$max_context_lines_before; $j > 0; $j--) {
+              $show_file .= "<br />Line #<strong>" . ($line_numpos-$j) . "</strong> : ";
+              $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($lines[($line_num-$j)], ENT_QUOTES, CHARSET);
+            }
+
             //prevent db pwd from being displayed, for sake of security
+            $show_file .= "<br>Line #<strong>{$line_numpos}</strong> : " ;
+            $show_file .= '<strong>';
             $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($line, ENT_QUOTES, CHARSET);
-            $show_file .= "<br />\n";
+            $show_file .= '</strong>';
+
+            for($j=1; $j < $max_context_lines_after+1; $j++) {
+              $show_file .= "<br>Line #<strong>" . ($line_numpos+$j) . "</strong> : ";
+              $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($lines[($line_num+$j)], ENT_QUOTES, CHARSET);
+            }
+            $show_file .= "<br>\n";
           } else {
             if ($cnt_lines >= 5) {
 //            $show_file .= ' .';

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -169,7 +169,7 @@
 
         // put file into an array to be scanned
         $lines = file($file);
-        $found_line = 'false';
+        $found_line = false;
         // loop through the array, show line and line numbers
         $cnt_lines = 0;
         foreach ($lines as $line_num => $line) {
@@ -185,8 +185,8 @@
             $check_case = false;
           }
           if ($check_case) {
-            $found_line= 'true';
-            $found = 'true';
+            $found_line = true;
+            $found = true;
             $cnt_found++;
             $line_numpos = $line_num + 1;
 
@@ -217,7 +217,7 @@
       $show_file .= '</td></tr></table>' . "\n";
 
       // if there was a match, show lines
-      if ($found_line == 'true') {
+      if ($found_line == true) {
         echo $show_file . '<table><tr><td>&nbsp;</td></tr></table>';
       } // show file
     }
@@ -230,7 +230,7 @@
   // don't do any 'action' if clicked on the Check for Updates button
   if (isset($_GET['vcheck']) && $_GET['vcheck']=='yes') $action = '';
 
-  $found= 'true';
+  $found= true;
 
   $search = (isset($_POST['search']) ? $_POST['search'] : '');
   $flags =  (isset($_GET['v']) ? '&v=' : '') . (isset($_GET['s']) ? '&s=' . preg_replace('/[^a-z]/', '', $_GET['s']) : '');
@@ -281,7 +281,7 @@
         $messageStack->add_session(ERROR_CONFIGURATION_KEY_NOT_ENTERED, 'caution');
         zen_redirect(zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT));
       }
-      $found = 'false';
+      $found = false;
       $zv_files_group = $_POST['zv_files'];
 
       $sql = "select *, (case when use_function = 'zen_cfg_password_display' then '********' else configuration_value end) as configuration_value from " . TABLE_CONFIGURATION . " where configuration_key=:zcconfigkey:";
@@ -337,14 +337,14 @@
               zen_display_files();
 
         } else {
-          $show_products_type_layout = 'true';
-          $show_configuration_info = 'true';
-          $found = 'true';
+          $show_products_type_layout = true;
+          $show_configuration_info = true;
+          $found = true;
         }
       } else {
-        $show_products_type_layout = 'false';
-        $show_configuration_info = 'true';
-        $found = 'true';
+        $show_products_type_layout = false;
+        $show_configuration_info = true;
+        $found = true;
       }
 
       break;
@@ -354,7 +354,7 @@
         $messageStack->add_session(ERROR_CONFIGURATION_KEY_NOT_ENTERED, 'caution');
         zen_redirect(zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT));
       }
-      $found = 'false';
+      $found = false;
       $zv_files_group = $_POST['zv_files'];
 
           // build filenames to search
@@ -392,7 +392,7 @@
         $messageStack->add_session(ERROR_CONFIGURATION_KEY_NOT_ENTERED, 'caution');
         zen_redirect(zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT));
       }
-      $found = 'false';
+      $found = false;
       $zv_files_group = $_POST['zv_files'];
 
           // build filenames to search
@@ -426,7 +426,7 @@
         $messageStack->add_session(ERROR_CONFIGURATION_KEY_NOT_ENTERED, 'caution');
         zen_redirect(zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT));
       }
-      $found = 'false';
+      $found = false;
       $zv_files_group = $_POST['zv_files'];
 
           // build filenames to search
@@ -492,7 +492,7 @@
         $messageStack->add_session(ERROR_CONFIGURATION_KEY_NOT_ENTERED, 'caution');
         zen_redirect(zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT));
       }
-      $found = 'false';
+      $found = false;
       $zv_files_group = $_POST['zv_files'];
       $zv_filestype_group = $_POST['zv_filestype'];
 //echo 'settings: ' . '$zv_files_group: ' . $zv_files_group . '$zv_filestype_group: ' . $zv_filestype_group . '<br>';
@@ -574,7 +574,7 @@
     } // eof: action
 
     // if no matches in either databases or selected language directory give an error
-    if ($found == 'false') {
+    if ($found == false) {
       $messageStack->add(ERROR_CONFIGURATION_KEY_NOT_FOUND . ' ' . zen_output_string_protected($configuration_key_lookup), 'caution');
     } elseif (substr($action, 0, 7) == 'locate_') {
       echo '<table width="90%" align="center"><tr><td>' . zen_draw_separator('pixel_black.gif', '100%', '2') . '</td></tr><tr><td>&nbsp;</td></tr></table>' . "\n";
@@ -600,8 +600,8 @@ require('includes/admin_html_head.php');
       </tr>
 
 <?php
-if (isset($show_configuration_info) && $show_configuration_info == 'true') {
-  $show_configuration_info = 'false';
+if (isset($show_configuration_info) && $show_configuration_info == true) {
+  $show_configuration_info = false;
 ?>
       <tr><td colspan="2">
         <table border="3" cellspacing="4" cellpadding="4">
@@ -621,7 +621,7 @@ if (isset($show_configuration_info) && $show_configuration_info == 'true') {
             <td class="dataTableHeadingContentWhois"><?php echo $check_configure->fields['configuration_description']; ?></td>
           </tr>
 <?php
-  if ($show_products_type_layout == 'true') {
+  if ($show_products_type_layout == true) {
     $check_configure_group = $db->Execute("select * from " . TABLE_PRODUCT_TYPES . " where type_id='" . (int)$check_configure->fields['product_type_id'] . "'");
   } else {
     $check_configure_group = $db->Execute("select * from " . TABLE_CONFIGURATION_GROUP . " where configuration_group_id='" . (int)$check_configure->fields['configuration_group_id'] . "'");
@@ -629,7 +629,7 @@ if (isset($show_configuration_info) && $show_configuration_info == 'true') {
 ?>
 
 <?php
-  if ($show_products_type_layout == 'true') {
+  if ($show_products_type_layout == true) {
 ?>
           <tr>
             <td class="infoBoxHeading"><?php echo TABLE_TITLE_GROUP; ?></td>
@@ -656,7 +656,7 @@ if (isset($show_configuration_info) && $show_configuration_info == 'true') {
           <tr>
             <td class="main" align="center" valign="middle">
               <?php
-                if ($show_products_type_layout == 'false' and ($check_configure->fields['configuration_id'] != 0 and $check_configure_group->fields['visible'] != 0)) {
+                if ($show_products_type_layout == false and ($check_configure->fields['configuration_id'] != 0 and $check_configure_group->fields['visible'] != 0)) {
                   echo '<a href="' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $check_configure_group->fields['configuration_group_id'] . '&cID=' . $check_configure->fields['configuration_id']) . '">' . zen_image_button('button_edit.gif', IMAGE_EDIT) . '</a>';
                 } else {
                   $page= '';
@@ -664,7 +664,7 @@ if (isset($show_configuration_info) && $show_configuration_info == 'true') {
                   if (strstr($check_configure->fields['configuration_key'], 'MODULE_PAYMENT')) $page .= 'payment';
                   if (strstr($check_configure->fields['configuration_key'], 'MODULE_ORDER_TOTAL')) $page .= 'ordertotal';
 
-                  if ($show_products_type_layout == 'true') {
+                  if ($show_products_type_layout == true) {
                     echo '<a href="' . zen_href_link(FILENAME_PRODUCT_TYPES) . '">' . zen_image_button('button_edit.gif', IMAGE_EDIT) . '</a>';
                   } else {
                     if ($page != '') {

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -53,8 +53,7 @@
   function zen_display_files($include_root = false, $filetypesincluded = 1) {
     global $check_directory, $found, $configuration_key_lookup;
     global $db;
-    $max_context_lines_before = 3;
-    $max_context_lines_after = 3;
+    $max_context_lines_before = $max_context_lines_after = abs((int)$_POST['context_lines']);
 
     $directory_array = array();
     for ($i = 0, $n = sizeof($check_directory); $i < $n; $i++) {
@@ -197,9 +196,9 @@
 
             //prevent db pwd from being displayed, for sake of security
             $show_file .= "<br>Line #<strong>{$line_numpos}</strong> : " ;
-            $show_file .= '<strong>';
+            if ($max_context_lines_before > 0) $show_file .= '<strong>';
             $show_file .= (substr_count($line,"'DB_SERVER_PASSWORD'")) ? '***HIDDEN***' : htmlspecialchars($line, ENT_QUOTES, CHARSET);
-            $show_file .= '</strong>';
+            if ($max_context_lines_before > 0) $show_file .= '</strong>';
 
             for($j=1; $j < $max_context_lines_after+1; $j++) {
               $show_file .= "<br>Line #<strong>" . ($line_numpos+$j) . "</strong> : ";
@@ -568,7 +567,8 @@
           }
           break;
         }
-          zen_display_files($zv_check_root, $zv_filestype_group);
+
+        zen_display_files($zv_check_root, $zv_filestype_group);
 
       break;
     } // eof: action
@@ -936,6 +936,7 @@ if ($action == 'search_config_keys') {
 
                 echo '<strong>' . TEXT_ALL_FILESTYPE_LOOKUPS . '</strong>' . '<br />' . zen_draw_pull_down_menu('zv_filestype', $za_lookup_filetype, 1);
                 echo '<label for="locate-cs">' . TEXT_CASE_SENSITIVE . ' </label>' . zen_draw_checkbox_field('case_sensitive', true, false, '', 'id="locate-cs"');
+                echo '<label for="context_lines"> ' . TEXT_CONTEXT_LINES . ' </label>' . zen_draw_input_field('context_lines', '3', 'id="context_lines" size="1"');
               ?>
             </td>
             <td class="main" align="right" valign="bottom"><?php echo zen_image_submit('button_search.gif', IMAGE_SEARCH); ?></td>

--- a/admin/includes/languages/english/developers_tool_kit.php
+++ b/admin/includes/languages/english/developers_tool_kit.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: developers_tool_kit.php 18698 2011-05-04 14:50:06Z wilt $
+ * @version $Id: developers_tool_kit.php DrByte  Modified in v1.6.0 $
  */
   define('HEADING_TITLE', 'Developers Tool Kit');
   define('TABLE_CONFIGURATION_TABLE', 'Lookup CONSTANT Definitions');
@@ -79,6 +79,7 @@
   define('TEXT_ALL_FILES_LOOKUP_JS', '.js only');
 
   define('TEXT_CASE_SENSITIVE', 'Case Sensitive?');
+  define('TEXT_CONTEXT_LINES', 'Context lines: ');
 
   //Search Configuration Keys
   define('SEARCH_CFG_KEYS_HEADING_TITLE','<strong>Search in Configuration Settings/Keys</strong>');

--- a/admin/includes/template/css/developers_tool_kit.css
+++ b/admin/includes/template/css/developers_tool_kit.css
@@ -5,7 +5,7 @@
  * @version $Id: Author: DrByte  Modified in v1.6.0 $
  */
 
-.dtk-highlite {font-weight: bold}
-.dtk-foundline {font-family: courier; background-color: rgba(255, 255, 0, 0.21);}
-.dtk-contextline {font-family: courier}
-.dtk-linenum {font-family: courier}
+.dtk-highlite {font-weight: bold; color: rgb(255, 10, 5);}
+.dtk-foundline {font-family: courier; background-color: rgba(4, 211, 216, 0.12);}
+.dtk-contextline {font-family: courier;}
+.dtk-linenum {font-family: courier;}

--- a/admin/includes/template/css/developers_tool_kit.css
+++ b/admin/includes/template/css/developers_tool_kit.css
@@ -6,6 +6,7 @@
  */
 
 .dtk-highlite {font-weight: bold; color: rgb(255, 10, 5);}
-.dtk-foundline {font-family: courier; background-color: rgba(4, 211, 216, 0.12);}
+.dtk-foundline, .dtk-foundline-multi {font-family: courier;}
+.dtk-foundline-multi {background-color: rgba(4, 211, 216, 0.12);}
 .dtk-contextline {font-family: courier;}
 .dtk-linenum {font-family: courier;}

--- a/admin/includes/template/css/developers_tool_kit.css
+++ b/admin/includes/template/css/developers_tool_kit.css
@@ -1,0 +1,11 @@
+/*
+ * @package Admin 
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Author: DrByte  Modified in v1.6.0 $
+ */
+
+.dtk-highlite {font-weight: bold}
+.dtk-foundline {font-family: courier; background-color: rgba(255, 255, 0, 0.21);}
+.dtk-contextline {font-family: courier}
+.dtk-linenum {font-family: courier}


### PR DESCRIPTION
Add related-context lines to results in dev toolkit

- shows prev+next 3 lines with search results (user-selectable # of lines)
- bolds the "found" line (styleable via CSS) and actual search text
