### PR TITLE
Banners miss fire and set wrong date

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -4,7 +4,7 @@
  * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: banner_manager.php 19330 2011-08-07 06:32:56Z drbyte $
+ * @version GIT: $Id: banner_manager.php Author: ajeh  Modified in v1.6.0 $
  */
 
   require('includes/application_top.php');
@@ -130,7 +130,7 @@
 
           $sql = "UPDATE " . TABLE_BANNERS . "
                   SET
-                    date_scheduled = :scheduledDate,
+                    date_scheduled = DATE_ADD(:scheduledDate, INTERVAL '00:00:00' HOUR_SECOND),
                     expires_date = DATE_ADD(:expiresDate, INTERVAL '23:59:59' HOUR_SECOND),
                     expires_impressions = " . ($expires_impressions == 0 ? "null" : ":expiresImpressions") . "
                     WHERE banners_id = :bannersID";

--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -134,15 +134,9 @@
                     expires_date = DATE_ADD(:expiresDate, INTERVAL '23:59:59' HOUR_SECOND),
                     expires_impressions = " . ($expires_impressions == 0 ? "null" : ":expiresImpressions") . "
                     WHERE banners_id = :bannersID";
-          if ($expires_impressions > 0) {
             $sql = $db->bindVars($sql, ':expiresImpressions', $expires_impressions, 'integer');
-          }
-          if ($date_scheduled != '') {
             $sql = $db->bindVars($sql, ':scheduledDate', $date_scheduled, 'date');
-          }
-          if ($expires_date != '') {
             $sql = $db->bindVars($sql, ':expiresDate', $expires_date, 'date');
-          }
             $sql = $db->bindVars($sql, ':bannersID', $banners_id, 'integer');
             $db->Execute($sql);
 

--- a/includes/functions/banner.php
+++ b/includes/functions/banner.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2013 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: banner.php 15580 2010-02-25 15:53:36Z ajeh $
+ * @version GIT: $Id: banner_manager.php Author: ajeh  Modified in v1.6.0 $
  */
 
   /**
@@ -31,7 +31,7 @@
     global $db;
     $banners_query = "select banners_id, date_scheduled
                       from " . TABLE_BANNERS . "
-                      where date_scheduled != NULL";
+                      where date_scheduled IS NOT NULL";
     $banners = $db->Execute($banners_query);
 
     if ($banners->RecordCount() > 0) {


### PR DESCRIPTION
Banners were not firing correctly for enable/disable and incorrect dates were being stored.

This affected the results in the Catalog and Admin.