### PR TITLE
widgets_default language file -- Multiple languages create debug logs

### DIFF
--- a/admin/includes/init_includes/init_languages.php
+++ b/admin/includes/init_includes/init_languages.php
@@ -58,7 +58,9 @@ if ($current_page != '' && file_exists(DIR_WS_LANGUAGES . $_SESSION ['language']
 
 // include additional files:
 require (DIR_WS_LANGUAGES . $_SESSION ['language'] . '/' . FILENAME_EMAIL_EXTRAS);
-include (DIR_WS_LANGUAGES . $_SESSION ['language'] . '/widgets_default.php');
+if (file_exists(DIR_WS_LANGUAGES . $_SESSION ['language'] . '/widgets_default.php')) { 
+  include (DIR_WS_LANGUAGES . $_SESSION ['language'] . '/widgets_default.php');
+}
 include (zen_get_file_directory(DIR_FS_CATALOG_LANGUAGES . $_SESSION ['language'] . '/', FILENAME_OTHER_IMAGES_NAMES, 'false'));
 
 if ($za_dir = @dir(DIR_WS_LANGUAGES . $_SESSION ['language'] . '/extra_definitions')) {


### PR DESCRIPTION
check for file existence to avoid log:
[21-Apr-2015 18:04:17 America/New_York] PHP Warning:  include(includes/languages/french/widgets_default.php): failed to open stream: No such file or directory in /Users/scott/Sites/demo_160/admin/includes/init_includes/init_languages.php on line 61