### PR TITLE
Remove unused variable $customers_ip_address from application_top

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -177,7 +177,6 @@ if (( (!file_exists('includes/configure.php') && !file_exists('includes/local/co
 require('includes/autoload_func.php');
 
 // get customer's unique IP that external gateway does not touch
-$customers_ip_address = $_SERVER['REMOTE_ADDR'];
 if (!isset($_SESSION['customers_ip_address'])) {
-  $_SESSION['customers_ip_address'] = $customers_ip_address;
+  $_SESSION['customers_ip_address'] = $_SERVER['REMOTE_ADDR'];
 }


### PR DESCRIPTION
Removed superfluous variable $customers_ip_address from application_top.php, after search revealed no instances of it being used.

I'm sorry if this minor change is a waste of time, but I really wanted to figure out the workflow for submitting changes so I can do more.  Please let me know if I'm doing everything correctly.
