### PR TITLE
multiple-add-to-cart button was missing from "bottom"

### DIFF
--- a/includes/library/zencart/platform/src/listingBox/boxes/AbstractListingBox.php
+++ b/includes/library/zencart/platform/src/listingBox/boxes/AbstractListingBox.php
@@ -2,9 +2,9 @@
 /**
  * Class AbstractListingBox
  *
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: currencies.php 15880 2010-04-11 16:24:30Z wilt $
+ * @version $Id: wilt  New in v1.6.0 $
  */
 namespace ZenCart\Platform\listingBox\boxes;
 /**
@@ -103,7 +103,7 @@ abstract class AbstractListingBox extends \base
         $showTopSubmit = $showForm;
         if ($showForm) {
             $showTopSubmit = (PRODUCT_LISTING_MULTIPLE_ADD_TO_CART == 1 || PRODUCT_LISTING_MULTIPLE_ADD_TO_CART == 3) ? true : false;
-            $showBottomSubmit = (PRODUCT_LISTING_MULTIPLE_ADD_TO_CART == 2) ? true : false;
+            $showBottomSubmit = (PRODUCT_LISTING_MULTIPLE_ADD_TO_CART >= 2) ? true : false;
         }
         $showForm = ($showTopSubmit || $showBottomSubmit);
         $this->tplVars['showMultiTopSubmit'] = $showTopSubmit;


### PR DESCRIPTION
The multiple-add-to-cart button was only showing on the "top" of the list, but not also the bottom when the option was set to `3=both`