### PR TITLE
Fix misspelling and accents for a few countries.

### DIFF
--- a/zc_install/sql/install/mysql_latin1.sql
+++ b/zc_install/sql/install/mysql_latin1.sql
@@ -12,7 +12,7 @@
 
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, use_function, set_function) VALUES ('Convert currencies for Text emails', 'CURRENCIES_TRANSLATIONS', '', 'What currency conversions do you need for Text emails?<br />Example = &amp;pound;,&pound;:&amp;euro;,&euro;', 12, 120, NULL, '2003-11-21 00:00:00', NULL, 'zen_cfg_textarea_small(');
 
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (240,'Aaland Islands','AX','ALA','1');
+INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (240,'Aland Islands','AX','ALA','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (1,'Afghanistan','AF','AFG','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (2,'Albania','AL','ALB','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (3,'Algeria','DZ','DZA','1');

--- a/zc_install/sql/install/mysql_utf8.sql
+++ b/zc_install/sql/install/mysql_utf8.sql
@@ -15,7 +15,7 @@
 
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, use_function, set_function) VALUES ('Convert currencies for Text emails', 'CURRENCIES_TRANSLATIONS', '&pound;,£:&euro;,€:&reg;,®:&trade;,™', 'What currency conversions do you need for Text emails?<br />Example = &amp;pound;,&pound;:&amp;euro;,&euro;', 12, 120, NULL, '2003-11-21 00:00:00', NULL, 'zen_cfg_textarea_small(');
 
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (240,'Aaland Islands','AX','ALA','1');
+INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (240,'Åland Islands','AX','ALA','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (1,'Afghanistan','AF','AFG','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (2,'Albania','AL','ALB','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (3,'Algeria','DZ','DZA','1');
@@ -67,7 +67,7 @@ INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, count
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (49,'Congo','CG','COG','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (50,'Cook Islands','CK','COK','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (51,'Costa Rica','CR','CRI','1');
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (52,"Cote D'Ivoire",'CI','CIV','1');
+INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (52,"Côte d'Ivoire",'CI','CIV','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (53,'Croatia','HR','HRV','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (54,'Cuba','CU','CUB','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (55,'Cyprus','CY','CYP','1');
@@ -188,7 +188,7 @@ INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, count
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (171,'Portugal','PT','PRT','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (172,'Puerto Rico','PR','PRI','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (173,'Qatar','QA','QAT','1');
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (174,'Reunion','RE','REU','1');
+INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (174,'Réunion','RE','REU','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (175,'Romania','RO','ROU','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (176,'Russian Federation','RU','RUS','1');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (177,'Rwanda','RW','RWA','1');

--- a/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
@@ -84,7 +84,7 @@ UPDATE countries set address_format_id = 7 where countries_iso_code_3 = 'AUS';
 UPDATE countries set address_format_id = 5 where countries_iso_code_3 IN ('BEL', 'NLD', 'SWE');
 UPDATE countries set countries_name = 'Åland Islands' where countries_iso_code_3 = 'ALA';
 UPDATE countries set countries_name = 'Réunion' where countries_iso_code_3 = 'REU';
-UPDATE countries set countries_name = 'Côte d'Ivoire' where countries_iso_code_3 = 'CIV';
+UPDATE countries set countries_name = "Côte d'Ivoire" where countries_iso_code_3 = 'CIV';
 
 ALTER TABLE countries ADD INDEX idx_status_zen (status, countries_id);
 

--- a/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
@@ -82,6 +82,9 @@ DELETE FROM configuration where configuration_key = 'PHPBB_LINKS_ENABLED' && con
 
 UPDATE countries set address_format_id = 7 where countries_iso_code_3 = 'AUS';
 UPDATE countries set address_format_id = 5 where countries_iso_code_3 IN ('BEL', 'NLD', 'SWE');
+UPDATE countries set countries_name = 'Åland Islands' where countries_iso_code_3 = 'ALA';
+UPDATE countries set countries_name = 'Réunion' where countries_iso_code_3 = 'REU';
+UPDATE countries set countries_name = 'Côte d'Ivoire' where countries_iso_code_3 = 'CIV';
 
 ALTER TABLE countries ADD INDEX idx_status_zen (status, countries_id);
 


### PR DESCRIPTION
Fix misspelling and accents for a few countries.

Note: No accents are used in latin1 mode, hence limited changes to that file.