### PR TITLE
Ajax paginator in the LEAD classes were not showing the correct URL

### DIFF
--- a/includes/library/zencart/Controllers/src/AbstractLeadController.php
+++ b/includes/library/zencart/Controllers/src/AbstractLeadController.php
@@ -43,6 +43,7 @@ abstract class AbstractLeadController extends AbstractController
         $this->queryBuilder = new QueryBuilder($this->dbConn, $this->listingBox->getListingQuery());
         $leadDef = $this->leadDefinitionBuilder->getleadDefinition();
         $this->paginator = new Paginator($request);
+        $this->paginator->setScrollerParams(array('mvcCmdName' => 'cmd'));
         $this->paginatortBuilder = new PaginatorBuilder($request, $this->listingBox->getListingQuery(),
             $this->paginator);
         $this->paginator->setAdapterParams(array('itemsPerPage' => $leadDef['paginationLimitDefault']));

--- a/includes/library/zencart/Paginator/src/Paginator.php
+++ b/includes/library/zencart/Paginator/src/Paginator.php
@@ -52,6 +52,8 @@ class Paginator extends \base
      */
     public function doPagination($adapterData, $adapterType = 'QueryFactory', $scrollerType = 'Standard')
     {
+        $mvcCmdName = issetorArray($this->scrollerParams, 'mvcCmdName', 'main_page');
+        $this->scrollerParams['cmd'] = $this->request->readGet($mvcCmdName);
         $pagingVarName = issetorArray($this->scrollerParams, 'pagingVarName', 'page');
         $pagingVarSrc = issetorArray($this->scrollerParams, 'pagingVarSrc', 'get');
         $currentPage = $this->request->get($pagingVarName, 1, $pagingVarSrc);

--- a/includes/library/zencart/listingBox/src/PaginatorBuilder.php
+++ b/includes/library/zencart/listingBox/src/PaginatorBuilder.php
@@ -38,7 +38,6 @@ class PaginatorBuilder
      */
     protected function buildPaginator($request, Paginator $paginator, array $listingQuery)
     {
-        $this->setDefaultParams($request, $paginator);
         if (!isset($listingQuery['pagination'])) {
             return;
         }
@@ -48,11 +47,6 @@ class PaginatorBuilder
         if (isset($listingQuery['pagination']['adapterParams'])) {
             $paginator->setAdapterParams($listingQuery['pagination']['adapterParams']);
         }
-    }
-
-    protected function setDefaultParams($request, Paginator $paginator)
-    {
-       $paginator->setScrollerParams(array('cmd'=>$request->readGet('main_page')));
     }
 
     /**


### PR DESCRIPTION
The paginator class was only looking for a get parameter of main_page to build URL links
Admin uses cmd=page
Problem was hidden because currently use of new pagination in admin is delivered via ajax

Note. Also browser url is not updated for ajax processed pagination
I intend to address this later, with some other updates to allow for a Cancel buttons on edit/add