### PR TITLE
Paypal introduction removed for orders over 10k, 5.5k

### DIFF
--- a/includes/templates/template_default/templates/tpl_login_default.php
+++ b/includes/templates/template_default/templates/tpl_login_default.php
@@ -21,6 +21,10 @@
 <!--BOF PPEC split login- DO NOT REMOVE-->
 <fieldset class="floatingBox back">
 <legend><?php echo HEADING_NEW_CUSTOMER_SPLIT; ?></legend>
+
+<?php //  Paypal doesn't allow over 10k in a single transaction,  This hides the introduction. ?>
+<?php if ( ($_SESSION['currency'] == 'USD' && $currencies->value($_SESSION['cart']->total, true, 'USD') > 10000) || ($_SESSION['currency'] == 'GBP' && $currencies->value($_SESSION['cart']->total, true, 'GBP') > 5500) ) $ec_button_enabled = false; ?>
+
 <?php // ** BEGIN PAYPAL EXPRESS CHECKOUT ** ?>
 <?php if ($ec_button_enabled) { ?>
 <div class="information"><?php echo TEXT_NEW_CUSTOMER_INTRODUCTION_SPLIT; ?></div>


### PR DESCRIPTION
While code is in place to hide the PayPal checkout button if orders are too large it doesn't hide the introduction text on the login page leading to a confusing paragraph about PayPal with no button to checkout with.

This fixes that.