### PR TITLE
Authorize.net Akamai endpoint change

### DIFF
--- a/extras/curltester.php
+++ b/extras/curltester.php
@@ -6,9 +6,9 @@
  *   r=1 -- show Response obtained from destination server -- this may contain an error message, but usually means communication was okay
  *
  * @package utilities
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte Wed Oct 22 2014 Modified in v1.5.4 $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.6.0 $
  */
 // no caching
 header('Cache-Control: no-cache, no-store, must-revalidate');
@@ -86,7 +86,7 @@ echo 'Connecting to Cardinal Commerce 3D-Secure Server ...<br>';
 doCurlTest('https://paypal.cardinalcommerce.com/maps/processormodule.asp');
 
 echo 'Connecting to AuthorizeNet Production Server ...<br>';
-doCurlTest('https://secure.authorize.net/gateway/transact.dll');
+doCurlTest('https://secure2.authorize.net/gateway/transact.dll');
 
 echo 'Connecting to AuthorizeNet Developer/Sandbox Server ...<br>';
 doCurlTest('https://test.authorize.net/gateway/transact.dll');

--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -80,7 +80,7 @@ class authorizenet extends base {
 
     if (is_object($order)) $this->update_status();
 
-    $this->form_action_url = 'https://secure.authorize.net/gateway/transact.dll';
+    $this->form_action_url = 'https://secure2.authorize.net/gateway/transact.dll';
 //     $this->form_action_url = 'https://www.eprocessingnetwork.com/cgi-bin/an/order.pl';
 
     if (AUTHORIZENET_DEVELOPER_MODE == 'on') $this->form_action_url = 'https://test.authorize.net/gateway/transact.dll';

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -626,7 +626,7 @@ class authorizenet_aim extends base {
       default:
       case 'AIM':
         $submit_data['x_solution_id'] = 'A1000003'; // used by authorize.net
-        $url = 'https://secure.authorize.net/gateway/transact.dll';
+        $url = 'https://secure2.authorize.net/gateway/transact.dll';
         if (defined('AUTHORIZENET_DEVELOPER_MODE')) {
           if (AUTHORIZENET_DEVELOPER_MODE == 'on') $url = $devurl;
           if (AUTHORIZENET_DEVELOPER_MODE == 'certify') $url = $certurl;

--- a/includes/modules/payment/authorizenet_echeck.php
+++ b/includes/modules/payment/authorizenet_echeck.php
@@ -3,10 +3,10 @@
  * authorize.net echeck payment method class
  *
  * @package paymentMethod
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Tue Aug 28 16:48:39 2012 -0400 Modified in v1.6.0 $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.6.0 $
  */
 /**
  * Authorize.net echeck Payment Module
@@ -561,7 +561,7 @@ class authorizenet_echeck extends base {
     }
 
     // set URL
-    $url = 'https://secure.authorize.net/gateway/transact.dll';
+    $url = 'https://secure2.authorize.net/gateway/transact.dll';
     $devurl = 'https://test.authorize.net/gateway/transact.dll';
     $dumpurl = 'https://developer.authorize.net/param_dump.asp';
     $certurl = 'https://certification.authorize.net/gateway/transact.dll';


### PR DESCRIPTION
Per Authorize.net developer bulletin July 14, 2015:

>The new Akamai transaction URLs that are available now are:
`https://api2.authorize.net/xml/v1/request.api`
`https://api2.authorize.net/soap/v1/Service.asmx`
`https://secure2.authorize.net/gateway/transact.dll`