### PR TITLE
Disable the SID check.

### DIFF
--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -349,8 +349,8 @@ class systemChecker
     $result = @session_start();
     if (!$result)
       RETURN FALSE;
-    if (defined('SID') && constant('SID') != "")
-      return FALSE;
+//    if (defined('SID') && constant('SID') != "")
+//      return FALSE;
 //    if (session_status() == PHP_SESSION_DISABLED)
 //      return FALSE;
     $_SESSION['testSession'] = 'testSession';


### PR DESCRIPTION
This causes problems on Ubuntu, and I dont think it will affect the installer on other platforms.
disabaling third/first party cookies in firefox doesn't trigger any errors.