### PR TITLE
Move message about missing order history to main admin language file

### DIFF
--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -224,6 +224,7 @@ define('JS_COUNTRY', '* The \'Country\' value must be chosen.\n');
 define('JS_TELEPHONE', '* The \'Telephone Number\' entry must have at least ' . ENTRY_TELEPHONE_MIN_LENGTH . ' characters.\n');
 
 define('JS_ORDER_DOES_NOT_EXIST', 'Order Number %s does not exist!');
+define('TEXT_NO_ORDER_HISTORY', 'No Order History Available');
 
 define('CATEGORY_PERSONAL', 'Personal');
 define('CATEGORY_ADDRESS', 'Address');

--- a/admin/includes/languages/english/orders.php
+++ b/admin/includes/languages/english/orders.php
@@ -70,7 +70,6 @@ define('TEXT_PAID', 'Paid');
 define('TEXT_UNPAID', 'Un-paid');
 
 define('TEXT_ALL_ORDERS', 'All Orders');
-define('TEXT_NO_ORDER_HISTORY', 'No Order History Available');
 
 define('EMAIL_SEPARATOR', '------------------------------------------------------');
 define('EMAIL_TEXT_SUBJECT', 'Order Update');


### PR DESCRIPTION
If the order history is missing, the invoice and packingslip pages will only show
TEXT_NO_ORDER_HISTORY, since this define is not available to them.