### PR TITLE
Add retry button to admin alert_page

### DIFF
--- a/admin/alert_page.php
+++ b/admin/alert_page.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: alert_page.php 19365 2011-08-28 19:53:48Z wilt $
+ * @version $Id: alert_page.php drbyte  Modified in v1.6.0 $
  */
 require ('includes/application_top.php');
 $adminDirectoryExists = $installDirectoryExists = FALSE;
@@ -40,8 +40,12 @@ if (!$adminDirectoryExists && !$installDirectoryExists)
   <li><?php echo ALERT_RENAME_ADMIN; ?><br><a href="http://www.zen-cart.com/content.php?75-admin-rename-instructions" target="_blank"><?php echo ADMIN_RENAME_FAQ_NOTE; ?></a></li>
   <?php  } ?>
   </ul>
+  <?php if ($adminDirectoryExists) { ?>
   <br />
   <p class=""><?php echo ALERT_PART2; ?></p>
+  <?php } else { ?>
+  <button class="button"><a href="<?php echo str_replace('?cmd=alert_page', '', $_SERVER['REQUEST_URI']);?>"><?php echo ALERT_CLICK_HERE; ?></a></button>
+  <?php } ?>
   </div>
 </body>
 </html>

--- a/admin/includes/languages/english/alert_page.php
+++ b/admin/includes/languages/english/alert_page.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2011 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: alert_page.php 19182 2011-07-21 23:41:51Z drbyte $
+ * @version $Id: alert_page.php drbyte  Modified in v1.6.0 $
  */
 
 define('HEADING_TITLE', 'Warning!');
@@ -12,3 +12,4 @@ define('ALERT_RENAME_ADMIN', 'renamed the admin folder.');
 define('ALERT_REMOVE_ZCINSTALL', 'deleted the zc_install folder.<br />(Use your FTP program or your hosting control panel.)');
 define('ADMIN_RENAME_FAQ_NOTE', 'Help for renaming the admin folder can be found here');
 define('ALERT_PART2', 'Then, to access your admin area, type the admin URL into your browser, ie: <u>http://www.your_site.com/YourAdminFolder/</u> ');
+define('ALERT_CLICK_HERE', 'Click to retry');


### PR DESCRIPTION
The retry link is only available if the admin folder has already been renamed but the zc_install has not. (... because we can't do a retry link if we don't know the name of the new admin folder yet)