### PR TITLE
Force to run zc_install over https if possible

### DIFF
--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -472,18 +472,19 @@ class systemChecker
   {
     global $request_type;
 
-    // take full URI and ping https version of same to see if expected response comes back. If so, redirect install to https.
-    if ($request_type != 'SSL' && function_exists('curl_init'))
+    // Take full URI and ping https version of same to see if expected response comes back. If so, redirect install to https.
+    // In case multiple-redirects happen on oddly-configured hosts, this can be bypassed by adding ?noredirect=1 to the URL
+    if ($request_type != 'SSL' && function_exists('curl_init') && !isset($_GET['noredirect']))
     {
       $test_uri = 'https://' . str_replace(array('http://', 'https://'), '', $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
       $resultCurl = self::curlGetUrl($test_uri);
       //error_log(print_r($resultCurl, true) . print_r($_SERVER, true));
       if (isset($resultCurl['http_code']) && $resultCurl['http_code'] == '200') {
         header('Location: ' . $test_uri);
-        die();
+        exit();
       }
     }
-    // otherwise, return the https status so the inspector can report it along with suggestions    
+    // otherwise, return the https status so the inspector can report it along with suggestions
     return ($request_type == 'SSL') ? TRUE : FALSE;
   }
   public function addRunlevel($runLevel)

--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -471,6 +471,19 @@ class systemChecker
   public function checkHttpsRequest($parameters)
   {
     global $request_type;
+
+    // take full URI and ping https version of same to see if expected response comes back. If so, redirect install to https.
+    if ($request_type != 'SSL' && function_exists('curl_init'))
+    {
+      $test_uri = 'https://' . str_replace(array('http://', 'https://'), '', $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+      $resultCurl = self::curlGetUrl($test_uri);
+      //error_log(print_r($resultCurl, true) . print_r($_SERVER, true));
+      if (isset($resultCurl['http_code']) && $resultCurl['http_code'] == '200') {
+        header('Location: ' . $test_uri);
+        die();
+      }
+    }
+    // otherwise, return the https status so the inspector can report it along with suggestions    
     return ($request_type == 'SSL') ? TRUE : FALSE;
   }
   public function addRunlevel($runLevel)


### PR DESCRIPTION
Tests whether zc_install can be done over https, and if so then redirects accordingly.
This helps the proper auto-detection of setup params, and also causes the db password and all other setup data to be transmitted over https instead of in clear text.

This detection only works with domain-specific certificates, not shared certificates.