### PR TITLE
Relocate T&C checkbox to be next to submit button

### DIFF
--- a/includes/templates/template_default/templates/tpl_checkout_payment_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_default.php
@@ -46,19 +46,6 @@
 <?php if ($messageStack->size('checkout') > 0) echo $messageStack->output('checkout'); ?>
 <?php if ($messageStack->size('checkout_payment') > 0) echo $messageStack->output('checkout_payment'); ?>
 
-<?php
-  if (DISPLAY_CONDITIONS_ON_CHECKOUT == 'true') {
-?>
-<fieldset>
-<legend><?php echo TABLE_HEADING_CONDITIONS; ?></legend>
-<div><?php echo TEXT_CONDITIONS_DESCRIPTION;?></div>
-<?php echo  zen_draw_checkbox_field('conditions', '1', false, 'id="conditions"');?>
-<label class="checkboxLabel" for="conditions"><?php echo TEXT_CONDITIONS_CONFIRM; ?></label>
-</fieldset>
-<?php
-  }
-?>
-
 <?php // ** BEGIN PAYPAL EXPRESS CHECKOUT **
       if (!$payment_modules->in_special_checkout()) {
       // ** END PAYPAL EXPRESS CHECKOUT ** ?>
@@ -227,6 +214,19 @@
 <legend><?php echo TABLE_HEADING_COMMENTS; ?></legend>
 <?php echo zen_draw_textarea_field('comments', '45', '3'); ?>
 </fieldset>
+
+<?php
+  if (DISPLAY_CONDITIONS_ON_CHECKOUT == 'true') {
+?>
+<fieldset>
+<legend><?php echo TABLE_HEADING_CONDITIONS; ?></legend>
+<div><?php echo TEXT_CONDITIONS_DESCRIPTION;?></div>
+<?php echo  zen_draw_checkbox_field('conditions', '1', false, 'id="conditions"');?>
+<label class="checkboxLabel" for="conditions"><?php echo TEXT_CONDITIONS_CONFIRM; ?></label>
+</fieldset>
+<?php
+  }
+?>
 
 <div class="buttonRow forward"><?php echo zen_image_submit(BUTTON_IMAGE_CONTINUE_CHECKOUT, BUTTON_CONTINUE_ALT, 'onclick="submitFunction('.zen_user_has_gv_account($_SESSION['customer_id']).','.$order->info['total'].')"'); ?></div>
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>


### PR DESCRIPTION
Fixes #535

Further enhancement could include javascript to disable the submit button until the box is checked ... but only if the feature is enabled