### PR TITLE
Disambiguation of $$ usage for PHP7 compatibility

### DIFF
--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -105,7 +105,7 @@ if (isset($_SESSION['payment_attempt'])) unset($_SESSION['payment_attempt']);
   $ototal = $order_subtotal = $credits_applied = 0;
   for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
     if ($order_totals[$i]['code'] == 'ot_subtotal') $order_subtotal = $order_totals[$i]['value'];
-    if ($$order_totals[$i]['code']->credit_class == true) $credits_applied += $order_totals[$i]['value'];
+    if (${$order_totals[$i]['code']}->credit_class == true) $credits_applied += $order_totals[$i]['value'];
     if ($order_totals[$i]['code'] == 'ot_total') $ototal = $order_totals[$i]['value'];
     if ($order_totals[$i]['code'] == 'ot_tax') $otax = $order_totals[$i]['value'];
     if ($order_totals[$i]['code'] == 'ot_shipping') $oshipping = $order_totals[$i]['value'];

--- a/includes/modules/payment/paypal/paypal_functions.php
+++ b/includes/modules/payment/paypal/paypal_functions.php
@@ -708,8 +708,8 @@
           if ($order_totals[$i]['code'] == 'ot_subtotal') $optionsST['subtotal'] = round($order_totals[$i]['value'],2);
         } else {
           // handle other order totals:
-          global $$order_totals[$i]['code'];
-          if ((substr($order_totals[$i]['text'], 0, 1) == '-') || (isset($$order_totals[$i]['code']->credit_class) && $$order_totals[$i]['code']->credit_class == true)) {
+          global ${$order_totals[$i]['code']};
+          if ((substr($order_totals[$i]['text'], 0, 1) == '-') || (isset(${$order_totals[$i]['code']}->credit_class) && ${$order_totals[$i]['code']}->credit_class == true)) {
             // handle credits
             $creditsApplied += round($order_totals[$i]['value'], 2);
           } else {

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -1530,8 +1530,8 @@ class paypaldp extends base {
           //$optionsST['SHIPDISCAMT'] = '';  // Not applicable
         } else {
           // handle other order totals:
-          global $$order_totals[$i]['code'];
-          if ((substr($order_totals[$i]['text'], 0, 1) == '-') || (isset($$order_totals[$i]['code']->credit_class) && $$order_totals[$i]['code']->credit_class == true)) {
+          global ${$order_totals[$i]['code']};
+          if ((substr($order_totals[$i]['text'], 0, 1) == '-') || (isset(${$order_totals[$i]['code']}->credit_class) && ${$order_totals[$i]['code']}->credit_class == true)) {
             // handle credits
             $creditsApplied += round($order_totals[$i]['value'], 2);
           } else {

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -1223,8 +1223,8 @@ if (false) { // disabled until clarification is received about coupons in PayPal
           //$optionsST['SHIPDISCAMT'] = '';  // Not applicable
         } else {
           // handle other order totals:
-          global $$order_totals[$i]['code'];
-          if ((substr($order_totals[$i]['text'], 0, 1) == '-') || (isset($$order_totals[$i]['code']->credit_class) && $$order_totals[$i]['code']->credit_class == true)) {
+          global ${$order_totals[$i]['code']};
+          if ((substr($order_totals[$i]['text'], 0, 1) == '-') || (isset(${$order_totals[$i]['code']}->credit_class) && ${$order_totals[$i]['code']}->credit_class == true)) {
             // handle credits
             $creditsApplied += round($order_totals[$i]['value'], 2);
           } else {

--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -152,9 +152,9 @@ Processing...
   }
 
   ipn_debug_email('Breakpoint: 2 - Validated transaction components');
-  if ($_POST ['exchange_rate'] == '')  $_POST [exchange_rate] = 1;
-  if ($_POST ['num_cart_items'] == '') $_POST [num_cart_items] = 1;
-  if ($_POST ['settle_amount'] == '')  $_POST [settle_amount] = 0;
+  if ($_POST['exchange_rate'] == '')  $_POST['exchange_rate'] = 1;
+  if ($_POST['num_cart_items'] == '') $_POST['num_cart_items'] = 1;
+  if ($_POST['settle_amount'] == '')  $_POST['settle_amount'] = 0;
 
   /**
    * is this a sandbox transaction?
@@ -362,7 +362,7 @@ Processing...
         $ototal = $order_subtotal = $credits_applied = 0;
         for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
           if ($order_totals[$i]['code'] == 'ot_subtotal') $order_subtotal = $order_totals[$i]['value'];
-          if ($$order_totals[$i]['code']->credit_class == true) $credits_applied += $order_totals[$i]['value'];
+          if (${$order_totals[$i]['code']}->credit_class == true) $credits_applied += $order_totals[$i]['value'];
           if ($order_totals[$i]['code'] == 'ot_total') $ototal = $order_totals[$i]['value'];
           if ($order_totals[$i]['code'] == 'ot_tax') $otax = $order_totals[$i]['value'];
           if ($order_totals[$i]['code'] == 'ot_shipping') $oshipping = $order_totals[$i]['value'];


### PR DESCRIPTION
These are some uses of indirect variables/properties/methods and globals which need some disambiguation for PHP 7 compatibility.

Ref: http://php.net/manual/en/migration70.incompatible.php
