### PR TITLE
Add `i` parameter to curltester for advanced debugging

### DIFF
--- a/extras/curltester.php
+++ b/extras/curltester.php
@@ -4,6 +4,7 @@
  * Accepted parameters:
  *   d=1 or details=1 -- show CURL connection details -- useful for determining cause of communications problems
  *   r=1 -- show Response obtained from destination server -- this may contain an error message, but usually means communication was okay
+ *   i=1 -- in conjunction with [d] or [r], will show the detailed curlinfo certificate data from the host being connected to. Helpful for advanced debugging.
  *
  * @package utilities
  * @copyright Copyright 2003-2015 Zen Cart Development Team
@@ -129,7 +130,7 @@ function doCurlTest($url = 'http://s3.amazonaws.com/zencart-curltest/endpoint', 
     curl_setopt($ch, CURLOPT_URL, $regs[1]);
   }
 
-  curl_setopt($ch, CURLOPT_VERBOSE, 1);
+  curl_setopt($ch, CURLOPT_VERBOSE, TRUE);
   curl_setopt($ch, CURLOPT_HEADER, 0);
   curl_setopt($ch, CURLOPT_TIMEOUT, 15);
   curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
@@ -139,6 +140,8 @@ function doCurlTest($url = 'http://s3.amazonaws.com/zencart-curltest/endpoint', 
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
   curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
   curl_setopt($ch, CURLOPT_USERAGENT, 'Zen Cart(tm) - CURL TEST');
+
+  if (isset($_GET['i'])) curl_setopt($ch, CURLOPT_CERTINFO, TRUE);
 
 //  curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 //  curl_setopt($ch, CURLOPT_CAINFO, '/local/path/to/cacert.pem'); // for offline testing, this file can be obtained from http://curl.haxx.se/docs/caextract.html ... should never be used in production!


### PR DESCRIPTION
This simply adds additional output to the CURL communications info, specifically about the certificate being connected to.  

This occasionally can be helpful when debugging, but I suspect will seldom be needed.