### PR TITLE
Add the ability to pass a logo URL ('x_logo_url') to Authorize.net SIM payments

### DIFF
--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -376,6 +376,7 @@ class authorizenet extends base {
       'x_relay_response' => 'TRUE',
       'x_relay_URL' => zen_href_link(FILENAME_CHECKOUT_PROCESS, 'action=confirm', 'SSL', true, false),
       'x_invoice_num' => '',
+      'x_logo_url' => (defined('MODULE_PAYMENT_AUTHORIZENET_LOGO_URL') ? MODULE_PAYMENT_AUTHORIZENET_LOGO_URL : ''),
       'x_duplicate_window' => '120',
       'x_allow_partial_Auth' => 'FALSE', // unable to accept partial authorizations at this time
       'x_description' => 'Website Purchase from ' . str_replace('"',"'", STORE_NAME),

--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -376,7 +376,6 @@ class authorizenet extends base {
       'x_relay_response' => 'TRUE',
       'x_relay_URL' => zen_href_link(FILENAME_CHECKOUT_PROCESS, 'action=confirm', 'SSL', true, false),
       'x_invoice_num' => '',
-      'x_logo_url' => (defined('MODULE_PAYMENT_AUTHORIZENET_LOGO_URL') ? MODULE_PAYMENT_AUTHORIZENET_LOGO_URL : ''),
       'x_duplicate_window' => '120',
       'x_allow_partial_Auth' => 'FALSE', // unable to accept partial authorizations at this time
       'x_description' => 'Website Purchase from ' . str_replace('"',"'", STORE_NAME),
@@ -411,7 +410,7 @@ class authorizenet extends base {
 //      'x_footer_html_payment_form' => '',
 //      'x_header_html_receipt' => '',
 //      'x_footer_html_receipt' => '',
-//      'x_logo_url' => '',
+        'x_logo_url' => (defined('MODULE_PAYMENT_AUTHORIZENET_LOGO_URL') ? MODULE_PAYMENT_AUTHORIZENET_LOGO_URL : ''),
 //      'x_background_url' => '',
 //      'x_color_link' => '',
 //      'x_color_background' => '',


### PR DESCRIPTION
On Sept 8, 2015 Authorize.net disabled the ability to set HTML/javascript/css markup in their custom payment page styling tools, in the interest of security. You can still customize your payment pages, but must do it via the settings in your authorize.net account directly on their website. However, one customization which you might want to pass along with your payments is the URL of the logo you wish to display. This code change allows for your store to send that logo URL.

(Other customization fields are NOT currently passed with payments. Instead, use the tools online in your account at authorize.net)

To activate the logo URL feature, simply add a define for `MODULE_PAYMENT_AUTHORIZENET_LOGO_URL` to the authorizenet.php language file `/includes/languages/english/modules/payment/authorizenet.php`

ie:
```php
define('MODULE_PAYMENT_AUTHORIZENET_LOGO_URL', 'https://example.com/images/my_store_logo.jpg');
```
Naturally you'll want to provide the correct URL to your actual logo file.