### PR TITLE
Reverse PR #464 - Authorize.net Akamai Servers

### DIFF
--- a/extras/curltester.php
+++ b/extras/curltester.php
@@ -90,6 +90,9 @@ echo 'Connecting to Cardinal Commerce 3D-Secure Server ...<br>';
 doCurlTest('https://paypal.cardinalcommerce.com/maps/processormodule.asp');
 
 echo 'Connecting to AuthorizeNet Production Server ...<br>';
+doCurlTest('https://secure.authorize.net/gateway/transact.dll');
+
+echo 'Connecting to AuthorizeNet Akamai Secondary Production Server ...<br>';
 doCurlTest('https://secure2.authorize.net/gateway/transact.dll');
 
 echo 'Connecting to AuthorizeNet Developer/Sandbox Server ...<br>';

--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -80,7 +80,7 @@ class authorizenet extends base {
 
     if (is_object($order)) $this->update_status();
 
-    $this->form_action_url = 'https://secure2.authorize.net/gateway/transact.dll';
+    $this->form_action_url = 'https://secure.authorize.net/gateway/transact.dll';
 //     $this->form_action_url = 'https://www.eprocessingnetwork.com/cgi-bin/an/order.pl';
 
     if (AUTHORIZENET_DEVELOPER_MODE == 'on') $this->form_action_url = 'https://test.authorize.net/gateway/transact.dll';

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -627,7 +627,7 @@ class authorizenet_aim extends base {
       default:
       case 'AIM':
         $submit_data['x_solution_id'] = 'A1000003'; // used by authorize.net
-        $url = 'https://secure2.authorize.net/gateway/transact.dll';
+        $url = 'https://secure.authorize.net/gateway/transact.dll';
         if (defined('AUTHORIZENET_DEVELOPER_MODE')) {
           if (AUTHORIZENET_DEVELOPER_MODE == 'on') $url = $devurl;
           if (AUTHORIZENET_DEVELOPER_MODE == 'certify') $url = $certurl;

--- a/includes/modules/payment/authorizenet_echeck.php
+++ b/includes/modules/payment/authorizenet_echeck.php
@@ -561,7 +561,7 @@ class authorizenet_echeck extends base {
     }
 
     // set URL
-    $url = 'https://secure2.authorize.net/gateway/transact.dll';
+    $url = 'https://secure.authorize.net/gateway/transact.dll';
     $devurl = 'https://test.authorize.net/gateway/transact.dll';
     $dumpurl = 'https://developer.authorize.net/param_dump.asp';
     $certurl = 'https://certification.authorize.net/gateway/transact.dll';


### PR DESCRIPTION
Using "secure2" instead of "secure" was only an intermediate step until they switched everything over to the new system.