### PR TITLE
Fixes #561 - leftover zc_install logs triggering warning in admin

### DIFF
--- a/admin/includes/init_includes/init_errors.php
+++ b/admin/includes/init_includes/init_errors.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version GIT: $Id: Author: Ian Wilson  Sun Jul 22 20:06:40 2012 +0100 Modified in v1.5.1 $
@@ -71,11 +71,11 @@ if (!defined('IS_ADMIN_FLAG')) {
     }
   }
 
-  // log cleanup
-  if ($za_dir = @dir(DIR_FS_SQL_CACHE)) {
+  // log cleanup for zc_install "info logs". This still leaves behind any zcInstallDEBUG or zcInstallException log files
+  if ($za_dir = @dir(DIR_FS_LOGS)) {
     while ($zv_file = $za_dir->read()) {
-      if (preg_match('/^zcInstall.*\.log$/', $zv_file)) {
-        unlink(DIR_FS_SQL_CACHE . '/' . $zv_file);
+      if (preg_match('/^zcInstallLog.*\.log$/', $zv_file)) {
+        unlink(DIR_FS_LOGS . '/' . $zv_file);
       }
     }
     $za_dir->close();


### PR DESCRIPTION
The change to `DIR_FS_LOGS` missed this instance of using the old `DIR_FS_SQL_CACHE`