### PR TITLE
Travis - Add github OAUTH support for composer to skip rate-limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ git:
   submodules: false
 
 before_install:
+  - composer self-update -q
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - git submodule update --init --recursive
 
 install:


### PR DESCRIPTION
Add OAUTH github support for composer on travis, to support API rate-limiting