### PR TITLE
Get rid of zc_install test for PHP CGI bug in PHP 5.4.0/5.4.1

### DIFF
--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -664,22 +664,6 @@ class systemChecker
     return TRUE;
   }
   /**
-   * Check to ensure that the PHP version is safe from the CGI bug introduced in 5.3 and present until 5.4.1
-   * ref: http://arstechnica.com/security/2014/03/php-bug-allowing-site-hijacking-still-menaces-internet-22-months-on/
-   * @return boolean
-   */
-  function checkIsPhpSafeFromCgiBug()
-  {
-    $phpVersion = PHP_VERSION;
-    if (version_compare(PHP_VERSION, '5.4.0', 'ge') && version_compare(PHP_VERSION, '5.4.2', 'lt')) {
-      if (stristr(php_sapi_name(), 'cgi')) {
-        // has bug, so not safe, thus return false:
-        return false;
-      }
-    }
-    return true;
-  }
-  /**
    * add current user IP to allowed-in-maintenance list
    */
   public function updateAdminIpList() {

--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -141,10 +141,9 @@ define('TEXT_ERROR_STORE_CONFIGURE', "Main /includes/configure.php file does not
 define('TEXT_ERROR_ADMIN_CONFIGURE', "Admin /admin/includes/configure.php does not exist (isn't readable) or is not writeable");
 define('TEXT_ERROR_PHP_VERSION', str_replace(array("\n", "\r"), '', 'Incorrect PHP Version.
 <p>The PHP version you are using (' . PHP_VERSION . ') is too old, and this version of Zen Cart&reg; cannot be used on this server in its present configuration.</p>
-<p>This version of Zen Cart&reg; is compatible with PHP versions 5.4.0 through 5.6.x.<br>
+<p>This version of Zen Cart&reg; is compatible with PHP versions 5.4.2+, 5.5.x, 5.6.x, and 7.0.<br>
 Check the <a href="www.zen-cart.com">www.zen-cart.com</a> website for the latest version of Zen Cart&reg;.</p>
 '));
-define('TEXT_ERROR_PHP53_CGI_BUG', 'PHP Versions PHP 5.4.0 and 5.4.1 have a <a href="http://arstechnica.com/security/2014/03/php-bug-allowing-site-hijacking" target="_blank">security flaw in CGI mode</a>. Your server has that flaw. You need to upgrade your PHP version to a modern safe version, or stop running in CGI mode.');
 define('TEXT_ERROR_PHP_VERSION_MIN', 'PHP Version should be greater than %s');
 define('TEXT_ERROR_PHP_VERSION_MAX', 'PHP Version should be less than %s');
 define('TEXT_ERROR_MYSQL_SUPPORT', 'Problems with your MySQL (mysqli) support');

--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -46,10 +46,9 @@ systemChecks:
       checkPhpVersionMax:
         method: checkPhpVersion
         parameters:
-          version: 5.6.99
-          versionTest: le
-          localErrorText: <?php echo sprintf(TEXT_ERROR_PHP_VERSION_MAX, '5.6.99') . PHP_EOL; ?>
-
+          version: 7.1.0
+          versionTest: lt
+          localErrorText: <?php echo sprintf(TEXT_ERROR_PHP_VERSION_MAX, '7.0.x') . PHP_EOL; ?>
   checkZCversion:
     runLevel: always
     errorLevel: WARN

--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -40,22 +40,15 @@ systemChecks:
       checkPhpVersionMin:
         method: checkPhpVersion
         parameters:
-          version: 5.4.0
+          version: 5.4.2
           versionTest: ge
-          localErrorText: <?php echo sprintf(TEXT_ERROR_PHP_VERSION_MIN, '5.4.0') . PHP_EOL; ?>
+          localErrorText: <?php echo sprintf(TEXT_ERROR_PHP_VERSION_MIN, '5.4.2') . PHP_EOL; ?>
       checkPhpVersionMax:
         method: checkPhpVersion
         parameters:
           version: 5.6.99
           versionTest: le
           localErrorText: <?php echo sprintf(TEXT_ERROR_PHP_VERSION_MAX, '5.6.99') . PHP_EOL; ?>
-
-  checkForPhpCgiSecurityBug:
-    runLevel: always
-    errorLevel: FAIL
-    mainErrorText: <?php echo TEXT_ERROR_PHP53_CGI_BUG .PHP_EOL; ?>
-    methods:
-      checkIsPhpSafeFromCgiBug:
 
   checkZCversion:
     runLevel: always


### PR DESCRIPTION
While PHP 5.4 is EOL, the ZC v160 code currently still works on PHP 5.4, so the minimum is being set to 5.4.2 for now (since 5.4.2 fixed the CGI bug)