### PR TITLE
Fixes #69 Guard against modifying product type in URL

### DIFF
--- a/admin/includes/auto_loaders/config.core.php
+++ b/admin/includes/auto_loaders/config.core.php
@@ -245,3 +245,11 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
                                  'loadFile'=> 'init_html_editor.php');
 
 
+/**
+ * Breakpoint 190.
+ *
+ * require('includes/init_includes/init_admin_history.php');
+ *
+ */
+  $autoLoadConfig[190][] = array('autoType'=>'init_script',
+                                 'loadFile'=> 'init_check_parms.php');

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2727,7 +2727,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . (int)$product_type . "'";
     $handler = $db->Execute($sql);
     if ($handler->EOF) { 
-          $messageStack->add('ERROR: Invalid type_handler. Your product_type settings are wrong, incomplete, or damaged.', 'error');
+          $messageStack->add('ERROR: Invalid product_type specified.', 'error');
           return -1;
     }
     return $handler->fields['type_handler'];

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2722,10 +2722,14 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  */
   function zen_get_handler_from_type($product_type) {
     global $db;
-
+    global $messageStack;
+    
     $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . (int)$product_type . "'";
     $handler = $db->Execute($sql);
-    if ($handler->EOF) return 'ERROR: Invalid type_handler. Your product_type settings are wrong, incomplete, or damaged.';
+    if ($handler->EOF) { 
+          $messageStack->add('ERROR: Invalid type_handler. Your product_type settings are wrong, incomplete, or damaged.', 'error');
+          return -1;
+    }
     return $handler->fields['type_handler'];
   }
 

--- a/admin/includes/init_includes/init_check_parms.php
+++ b/admin/includes/init_includes/init_check_parms.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package admin
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+if (!defined('IS_ADMIN_FLAG')) {
+  die('Illegal Access');
+}
+if (isset($_GET['product_type'])) { 
+  $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . (int)$_GET['product_type'] . "'";
+  $products_type_check = $db->Execute($sql); 
+  if ($products_type_check->EOF) {
+      unset($_GET['product_type']); 
+  }
+}

--- a/admin/includes/init_includes/init_check_parms.php
+++ b/admin/includes/init_includes/init_check_parms.php
@@ -8,8 +8,6 @@
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
-if (isset($_GET['product_type'])) { 
-  if (zen_get_handler_from_type((int)$_GET['product_type']) == -1) {
+if (isset($_GET['product_type']) && (zen_get_handler_from_type((int)$_GET['product_type']) == -1)) {
       unset($_GET['product_type']); 
-  }
 }

--- a/admin/includes/init_includes/init_check_parms.php
+++ b/admin/includes/init_includes/init_check_parms.php
@@ -2,7 +2,6 @@
 /**
  * @package admin
  * @copyright Copyright 2003-2015 Zen Cart Development Team
- * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 if (!defined('IS_ADMIN_FLAG')) {

--- a/admin/includes/init_includes/init_check_parms.php
+++ b/admin/includes/init_includes/init_check_parms.php
@@ -9,9 +9,7 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 if (isset($_GET['product_type'])) { 
-  $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . (int)$_GET['product_type'] . "'";
-  $products_type_check = $db->Execute($sql); 
-  if ($products_type_check->EOF) {
+  if (zen_get_handler_from_type((int)$_GET['product_type']) == -1) {
       unset($_GET['product_type']); 
   }
 }


### PR DESCRIPTION
Test Case: 
https://zen.local/admin/index.php?cmd=product_free_shipping&page=1&product_type=999&cPath=64&pID=172&action=new_product

without my change, will issue a debug log and a blank page.  With my fix, will go to the product but ignore the product_type change.