### PR TITLE
Updating password compatability code

### DIFF
--- a/includes/functions/password_funcs.php
+++ b/includes/functions/password_funcs.php
@@ -3,10 +3,10 @@
  * password_funcs functions
  *
  * @package functions
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version
+ * @version $Id: Modified in v1.6.0 $
  */
 // //
 // This function validates a plain text password with an encrpyted password
@@ -16,22 +16,28 @@ function zen_validate_password($plain, $encrypted, $userRef = NULL)
   return $zcPassword->validatePassword($plain, $encrypted);
 }
 
-// //
-// This function makes a new password from a plaintext password.
+/**
+ * This function makes a new password from a plaintext password.
+ * if php >= 5.5.0 we use inbuilt password_hash function.
+ * otherwise we use zen_encrypt_password_new to create a salted sha256 password.
+ * @param $plain
+ * @return string
+ */
 function zen_encrypt_password($plain)
 {
-  $password = '';
-
-  for($i = 0; $i < 10; $i ++) {
-    $password .= zen_rand();
-  }
-
-  $salt = substr(md5($password), 0, 2);
-
-  $password = md5($salt . $plain) . ':' . $salt;
-
-  return $password;
+    if (function_exists('password_hash')) {
+        $password = password_hash($plain, PASSWORD_DEFAULT);
+    } else {
+        $password = zen_encrypt_password_new($plain);
+    }
+    return $password;
 }
+
+/**
+ * this function makes a sha256 password from a plaintext password.
+ * @param $plain
+ * @return string
+ */
 function zen_encrypt_password_new($plain)
 {
   $password = '';

--- a/zc_install/includes/functions/password_funcs.php
+++ b/zc_install/includes/functions/password_funcs.php
@@ -3,10 +3,10 @@
  * password_funcs functions
  *
  * @package functions
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version
+ * @version $Id: Modified in v1.6.0 $
  */
 
 require_once (__DIR__ . '/../../../includes/classes/class.zcPassword.php');
@@ -39,22 +39,37 @@ function zen_validate_password($plain, $encrypted) {
   return false;
 }
 
-////
-// This function makes a new password from a plaintext password.
+/**
+ * This function makes a new password from a plaintext password.
+ * if php >= 5.5.0 we use inbuilt password_hash function.
+ * otherwise we use zen_encrypt_password_sha256 to create a salted sha256 password.
+ * @param $plain
+ * @return string
+ */
 function zen_encrypt_password($plain)
 {
-  $password = '';
+    if (function_exists('password_hash')) {
+        $password = password_hash($plain, PASSWORD_DEFAULT);
+    } else {
+        $password = zen_encrypt_password_sha256($plain);
+    }
+    return $password;
+}
 
-  for ($i = 0; $i < 10; $i++)
-  {
-    $password .= zen_rand();
-  }
-
-  $salt = substr(md5($password), 0, 2);
-
-  $password = md5($salt . $plain) . ':' . $salt;
-
-  return $password;
+/**
+ * this function makes a sha256 password from a plaintext password.
+ * @param $plain
+ * @return string
+ */
+function zen_encrypt_password_sha256($plain)
+{
+    $password = '';
+    for($i = 0; $i < 40; $i ++) {
+        $password .= zen_rand();
+    }
+    $salt = hash('sha256', $password);
+    $password = hash('sha256', $salt . $plain) . ':' . $salt;
+    return $password;
 }
 ////
 function zen_create_random_value($length, $type = 'mixed')


### PR DESCRIPTION
passwords were originally being generated using old style md5 hashes.
and while the passwords would have been updated to bcrypt on subsequent logins
better to get them right from the start.