### PR TITLE
New View and TplVarManager classes

### DIFF
--- a/includes/autoload_namespaces.php
+++ b/includes/autoload_namespaces.php
@@ -16,6 +16,7 @@ define('NAMESPACE_CONTROLLERS', 'ZenCart\Controllers');
 define('NAMESPACE_SERVICES', 'ZenCart\Services');
 define('NAMESPACE_AJAXDISPATCH', 'ZenCart\AjaxDispatch');
 define('NAMESPACE_LEAD', 'ZenCart\Lead');
+define('NAMESPACE_VIEW', 'ZenCart\View');
 
 define('URL_SERVICES', 'zencart/Services/src/');
 define('URL_CONTROLLERS', 'zencart/Controllers/src/');
@@ -26,6 +27,7 @@ define('URL_PAGINATOR', 'zencart/Paginator/src/');
 define('URL_QUERYBUILDER', 'zencart/QueryBuilder/src/');
 define('URL_REQUEST', 'zencart/Request/src/');
 define('URL_LEAD', 'zencart/Lead/src/');
+define('URL_VIEW', 'zencart/View/src/');
 
 /**
  * An array of namespace => basedir configurations
@@ -41,4 +43,5 @@ return array(
     NAMESPACE_QUERYBUILDER => DIR_CATALOG_LIBRARY. URL_QUERYBUILDER,
     NAMESPACE_REQUEST => DIR_CATALOG_LIBRARY. URL_REQUEST,
     NAMESPACE_LEAD => DIR_CATALOG_LIBRARY. URL_LEAD,
+    NAMESPACE_VIEW => DIR_CATALOG_LIBRARY. URL_VIEW,
 );

--- a/includes/init_includes/init_header.php
+++ b/includes/init_includes/init_header.php
@@ -3,7 +3,7 @@
  * header code, mainly concerned with adding to messagestack when certain warnings are applicable
  *
  * @package templateStructure
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:
@@ -152,3 +152,5 @@ if ($_SESSION['customer_id'] && zcRequest::readGet('main_page') != FILENAME_ADDR
     $addresses->MoveNext();
   }
 }
+$zcTplManager = new \ZenCart\View\TplVarManager();
+$zcView = new \ZenCart\View\View($zcTplManager, $messageStack, $breadcrumb);

--- a/includes/library/zencart/View/src/TplVarManager.php
+++ b/includes/library/zencart/View/src/TplVarManager.php
@@ -21,21 +21,24 @@ class TplVarManager extends \base
      * @param $key
      * @param $value
      */
-    public function setTplVar($key, $value)
+    public function set($key, $value)
     {
         $this->tplVars[$key] = $value;
     }
 
     /**
-     *
+     * @param bool $onlyAsArray
      */
-    public function globalizeTplVars()
+    public function globalize($onlyAsArray = false)
     {
-        foreach ($this->tplVars as $tplVarName => $tplVarValue) {
-            $GLOBALS[$tplVarName] = $tplVarValue;
-        }
         $tplVars = issetorArray($GLOBALS, 'tplVars', array());
         $tplVars = array_merge($tplVars, $this->tplVars);
         $GLOBALS['tplVars'] = $tplVars;
+        if ($onlyAsArray) {
+            return;
+        }
+        foreach ($this->tplVars as $tplVarName => $tplVarValue) {
+            $GLOBALS[$tplVarName] = $tplVarValue;
+        }
     }
 }

--- a/includes/library/zencart/View/src/TplVarManager.php
+++ b/includes/library/zencart/View/src/TplVarManager.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version  $Id: New in v1.6.0 $
+ */
+namespace ZenCart\View;
+
+/**
+ * Class TplVarManager
+ * @package ZenCart\View
+ */
+class TplVarManager extends \base
+{
+    /**
+     * @var array
+     */
+    protected $tplVars = [];
+
+    /**
+     * @param $key
+     * @param $value
+     */
+    public function setTplVar($key, $value)
+    {
+        $this->tplVars[$key] = $value;
+    }
+
+    /**
+     *
+     */
+    public function globalizeTplVars()
+    {
+        foreach ($this->tplVars as $tplVarName => $tplVarValue) {
+            $GLOBALS[$tplVarName] = $tplVarValue;
+        }
+        $tplVars = issetorArray($GLOBALS, 'tplVars', array());
+        $tplVars = array_merge($tplVars, $this->tplVars);
+        $GLOBALS['tplVars'] = $tplVars;
+    }
+}

--- a/includes/library/zencart/View/src/View.php
+++ b/includes/library/zencart/View/src/View.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version  $Id: New in v1.6.0 $
+ */
+
+namespace ZenCart\View;
+
+/**
+ * Class View
+ * @package ZenCart\View
+ */
+class View extends \base
+{
+
+    /**
+     * @var \messageStack
+     */
+    protected $messageStack;
+    /**
+     * @var \BreadCrumb
+     */
+    protected $breadCrumb;
+    /**
+     * @var TplVarManager
+     */
+    protected $tplVarManager;
+
+    /**
+     * @param TplVarManager $tplVarManager
+     * @param \messageStack $messageStack
+     * @param \BreadCrumb $breadCrumb
+     */
+    public function __construct(\ZenCart\View\TplVarManager $tplVarManager, \messageStack $messageStack, \BreadCrumb $breadCrumb)
+    {
+        $this->messageStack = $messageStack;
+        $this->breadCrumb = $breadCrumb;
+        $this->tplVarManager = $tplVarManager;
+    }
+
+    /**
+     * @return \messageStack
+     */
+    public function getMessageStack()
+    {
+        return $this->messageStack;
+    }
+
+    /**
+     * @return \BreadCrumb
+     */
+    public function getBreadCrumb()
+    {
+        return $this->breadCrumb;
+    }
+
+    /**
+     * @return TplVarManager
+     */
+    public function getTplVarManager()
+    {
+        return $this->tplVarManager;
+    }
+}


### PR DESCRIPTION
A lot of new code

e.g. ListingBoxes, LEAD stuff, CheckoutFlow use tplVars (Template Variables) to set variables that will be displayed/used in templates.
They need to do this to change the scope of the variables from the class they are created in to the global scope that template files exist in.
The problem is that each infrastructure has to repeat common methods to set/manage template variables.
Better to have common class that managed the template variables.
Further more (at least in catalog side code) we currently need to access things like the messaageStack/BreadCrumbs classes.
Rather than accessing Global stated, again better to pass in a View class that can access these common classes.