### PR TITLE
Fix UTF8 sequence error in ajax call

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -21,7 +21,7 @@ if (isset ($_GET['act'])&&isset ($_GET['method'])) {
           $class,
           $_GET['method']
       ));
-      $result = htmlentities((string)$result, ENT_QUOTES, 'utf-8', FALSE);
+      $result = htmlentities_recurse((string)$result, ENT_QUOTES, 'utf-8', FALSE);
       echo json_encode ($result);exit();
     } else {
       echo 'method error';

--- a/ajax.php
+++ b/ajax.php
@@ -21,7 +21,7 @@ if (isset ($_GET['act'])&&isset ($_GET['method'])) {
           $class,
           $_GET['method']
       ));
-      $result = htmlentities_recurse((string)$result, ENT_QUOTES, 'utf-8', FALSE);
+      $result = htmlentities_recurse($result, ENT_QUOTES, 'utf-8', FALSE);
       echo json_encode ($result);exit();
     } else {
       echo 'method error';

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -7,7 +7,7 @@
  * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Wed Feb 19 15:57:35 2014 +0000 Modified in v1.5.3 $
+ * @version GIT: $Id: Author: Ian Wilson  Wed Feb 19 15:57:35 2014 +0000 Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -1652,6 +1652,28 @@ if (!defined('IS_ADMIN_FLAG')) {
   function issetorArray(array $array, $key, $default = null) {
       return isset($array[$key]) ? $array[$key] : $default;
   }
+
+  /**
+   * @param $mixed_value
+   * @param int $flags
+   * @param string $encoding
+   * @param bool $double_encode
+   * @return array|string
+   */
+  function htmlentities_recurse($mixed_value, $flags = ENT_QUOTES, $encoding = 'utf-8', $double_encode = true) {
+      $result = array();
+      if (!is_array ($mixed_value)) {
+          return htmlentities ((string)$mixed_value, $flags, $encoding, $double_encode);
+      }
+      if (is_array($mixed_value)) {
+          $result = array ();
+          foreach ($mixed_value as $key => $value) {
+              $result[$key] = htmlentities_recurse ($value, $flags, $encoding, $double_encode);
+          }
+      }
+      return $result;
+  }
+
   /////////////////////////////////////////////
 ////
 // call additional function files

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -7,7 +7,7 @@
  * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Wed Feb 19 15:57:35 2014 +0000 Modified in v1.6.0 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');

--- a/testFramework/unittests/testsSundry/HtmlEntityRecurseTest.php
+++ b/testFramework/unittests/testsSundry/HtmlEntityRecurseTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package tests
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id$
+ */
+
+/**
+ * Class testHtmlEntityRecurse
+ */
+class testHtmlEntityRecurse extends zcTestCase
+{
+    /**
+     *
+     */
+    public function setup()
+    {
+        parent::setup();
+        require DIR_FS_CATALOG . 'includes/functions/functions_general.php';
+    }
+
+    /**
+     *
+     */
+    public function testRecurse()
+    {
+        $test = "<script>";
+        $result = htmlentities_recurse($test);
+        $this->assertEquals($result, '&lt;script&gt;');
+        $test = array('value' => "<script>");
+        $result = htmlentities_recurse($test);
+        $this->assertEquals($result['value'], '&lt;script&gt;');
+        $test = array(array('value'=>"<script>", 'value1' =>"<script>"), 'value' => "<script>");
+        $result = htmlentities_recurse($test);
+        $this->assertEquals($result[0]['value'], '&lt;script&gt;');
+        $this->assertEquals($result[0]['value1'], '&lt;script&gt;');
+        $this->assertEquals($result['value'], '&lt;script&gt;');
+    }
+}


### PR DESCRIPTION
The original fix didn't allow for multiple depth arrays.
see https://www.zen-cart.com/showthread.php?21669124&p=1294488#post1294488
I have based the code on that posted by @lat9 in the thread and added a unittest.