### PR TITLE
Parsing config file values incorrectly

### DIFF
--- a/zc_install/includes/classes/class.zcConfigureFileReader.php
+++ b/zc_install/includes/classes/class.zcConfigureFileReader.php
@@ -87,7 +87,7 @@ class zcConfigureFileReader {
 		if(!$this->fileLoaded()) return null;
 
 		// Extract the contents of the define
-		if(preg_match('|define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
+		if(preg_match('|\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
 			return $matches[1];
 		}
 		return null;

--- a/zc_install/includes/classes/class.zcConfigureFileReader.php
+++ b/zc_install/includes/classes/class.zcConfigureFileReader.php
@@ -87,7 +87,7 @@ class zcConfigureFileReader {
 		if(!$this->fileLoaded()) return null;
 
 		// Extract the contents of the define
-		if(preg_match('|\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
+		if(preg_match('|^\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
 			return $matches[1];
 		}
 		return null;


### PR DESCRIPTION
The zcConfigureFileReader class attempts to read define values via a pattern match.
However the original pattern would match against commented values e.g. starting with //