### PR TITLE
Backward compatibility for media-copy checkbox handling

### DIFF
--- a/admin/includes/modules/product_music/copy_to_confirm.php
+++ b/admin/includes/modules/product_music/copy_to_confirm.php
@@ -99,7 +99,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 
             $dup_products_id = $db->Insert_ID();
 
-            if (isset($_POST['copy_media']) && $_POST['copy_media'] == '1') {
+            if (isset($_POST['copy_media']) && ($_POST['copy_media'] == '1' || $_POST['copy_media'] == 'on')) {
               $product_media = $db->Execute("select media_id from " . TABLE_MEDIA_TO_PRODUCTS . "
                                              where product_id = '" . (int)$products_id . "'");
               while (!$product_media->EOF) {


### PR DESCRIPTION
Since both 'on' and '1' have been used, and different browsers are giving different results, this change accommodates both, and will allow for potentially-missed file changes in upgrades/plugins.