### PR TITLE
Fixing some hhvm unittest errors

### DIFF
--- a/includes/library/zencart/listingBox/src/formatters/ListStandard.php
+++ b/includes/library/zencart/listingBox/src/formatters/ListStandard.php
@@ -157,7 +157,6 @@ class ListStandard extends AbstractFormatter implements FormatterInterface
      */
     protected function processColumnEntries($queryResult, $columnName, $item)
     {
-        reset($queryResult);
         foreach ($queryResult as $dispSortOrder) {
             foreach ($this->displayValues as $key => $value) {
                 if ($dispSortOrder ['configuration_key'] == $this->prefix . $key) {

--- a/testFramework/unittests/testsHtmlOutput/AdminCatalogUrlGenerationTest.php
+++ b/testFramework/unittests/testsHtmlOutput/AdminCatalogUrlGenerationTest.php
@@ -101,6 +101,7 @@ class testAdminCatalogUrlGeneration extends zcTestCase
         @ini_set('log_errors_max_len', 0);  // unlimited length of message output
         @ini_set('display_errors', 0);      // do not output errors to screen/browser/client
         @ini_set('error_log', TESTCWD . 'log-myDEBUG.txt');
+        @ini_set('error_log', TESTCWD . 'log-myDEBUG.txt');
 
         $this->assertURLGenerated(
             zen_catalog_href_link(FILENAME_DEFAULT, null, 'OTHER'),

--- a/testFramework/unittests/testsHtmlOutput/CatalogUrlGenerationTest.php
+++ b/testFramework/unittests/testsHtmlOutput/CatalogUrlGenerationTest.php
@@ -118,7 +118,7 @@ class testCatalogUrlGeneration extends zcTestCase
         @ini_set('error_log', TESTCWD . 'log-myDEBUG.txt');
 
         $this->assertURLGenerated(
-            zen_href_link(FILENAME_DEFAULT, '', 'OTHER'),
+            zen_href_link(FILENAME_DEFAULT, null, 'OTHER'),
             HTTP_SERVER . DIR_WS_CATALOG
         );
 

--- a/testFramework/unittests/testsHtmlOutput/CatalogUrlGenerationTest.php
+++ b/testFramework/unittests/testsHtmlOutput/CatalogUrlGenerationTest.php
@@ -115,9 +115,10 @@ class testCatalogUrlGeneration extends zcTestCase
         @ini_set('log_errors_max_len', 0);  // unlimited length of message output
         @ini_set('display_errors', 0);      // do not output errors to screen/browser/client
         @ini_set('error_log', TESTCWD . 'log-myDEBUG.txt');
+        @ini_set('error_log', TESTCWD . 'log-myDEBUG.txt');
 
         $this->assertURLGenerated(
-            zen_href_link(FILENAME_DEFAULT, null, 'OTHER'),
+            zen_href_link(FILENAME_DEFAULT, '', 'OTHER'),
             HTTP_SERVER . DIR_WS_CATALOG
         );
 


### PR DESCRIPTION
remove incorrect reset for queryfactory
Bug in hhvm for error_log