### PR TITLE
Messages should be shown even if cart is empty

### DIFF
--- a/includes/templates/template_default/templates/tpl_shopping_cart_default.php
+++ b/includes/templates/template_default/templates/tpl_shopping_cart_default.php
@@ -13,6 +13,8 @@
  */
 ?>
 <div class="centerColumn" id="shoppingCartDefault">
+<?php if ($messageStack->size('shopping_cart') > 0) echo $messageStack->output('shopping_cart'); ?>
+
 <?php
   if ($flagHasCartContents) {
 ?>
@@ -26,8 +28,6 @@
 ?>
 
 <h1 id="cartDefaultHeading"><?php echo HEADING_TITLE; ?></h1>
-
-<?php if ($messageStack->size('shopping_cart') > 0) echo $messageStack->output('shopping_cart'); ?>
 
 <?php echo zen_draw_form('cart_quantity', zen_href_link(FILENAME_SHOPPING_CART, 'action=update_product', $request_type), 'post', 'id="shoppingCartForm"'); ?>
 <div id="cartInstructionsDisplay" class="content"><?php echo TEXT_INFORMATION; ?></div>


### PR DESCRIPTION
If an error occurs but the cart is still empty (perhaps because adding to the cart failed), the messages should still be shown at the top of the shopping cart page. 