### PR TITLE
zcInstall pattern matching when reading config file entries was broken.

### DIFF
--- a/zc_install/includes/classes/class.zcConfigureFileReader.php
+++ b/zc_install/includes/classes/class.zcConfigureFileReader.php
@@ -49,7 +49,7 @@ class zcConfigureFileReader {
 			if(file_exists($realfile)) {
 				$this->file = $realfile;
 				$content = file($realfile);
-                $content = implode('~**~', $content);
+                                $content = implode('~**~', $content);
 				if($content !== false && trim($content) !== '')
 					$this->fileContent = $content;
 			}
@@ -88,7 +88,7 @@ class zcConfigureFileReader {
 		if(!$this->fileLoaded()) return null;
 
 		// Extract the contents of the define
-        if (preg_match('|\~\*\*\~\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
+                if (preg_match('|\~\*\*\~\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
 			return $matches[1];
 		}
 		return null;

--- a/zc_install/includes/classes/class.zcConfigureFileReader.php
+++ b/zc_install/includes/classes/class.zcConfigureFileReader.php
@@ -48,7 +48,8 @@ class zcConfigureFileReader {
 			$realfile = realpath($file);
 			if(file_exists($realfile)) {
 				$this->file = $realfile;
-				$content = @file_get_contents($realfile);
+				$content = file($realfile);
+                $content = implode('~**~', $content);
 				if($content !== false && trim($content) !== '')
 					$this->fileContent = $content;
 			}
@@ -87,7 +88,7 @@ class zcConfigureFileReader {
 		if(!$this->fileLoaded()) return null;
 
 		// Extract the contents of the define
-		if(preg_match('|^\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
+        if (preg_match('|\~\*\*\~\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
 			return $matches[1];
 		}
 		return null;

--- a/zc_install/includes/classes/class.zcConfigureFileReader.php
+++ b/zc_install/includes/classes/class.zcConfigureFileReader.php
@@ -49,7 +49,7 @@ class zcConfigureFileReader {
 			if(file_exists($realfile)) {
 				$this->file = $realfile;
 				$content = file($realfile);
-                                $content = implode('~**~', $content);
+				$content = implode('~**~', $content);
 				if($content !== false && trim($content) !== '')
 					$this->fileContent = $content;
 			}
@@ -88,7 +88,7 @@ class zcConfigureFileReader {
 		if(!$this->fileLoaded()) return null;
 
 		// Extract the contents of the define
-                if (preg_match('|\~\*\*\~\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
+		if (preg_match('|\~\*\*\~\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
 			return $matches[1];
 		}
 		return null;


### PR DESCRIPTION
The problem was that the config file would be loaded as a contigous string, and the regex was trying to anchor at the start of the string.
There is probably a better way to do this but for now, will load the config file as an array of lines then implode with a custom seprarator.
Can then key the regex to look for the separator.