### PR TITLE
parsing configure.php not working correctly in installer.

### DIFF
--- a/zc_install/includes/classes/class.zcConfigureFileReader.php
+++ b/zc_install/includes/classes/class.zcConfigureFileReader.php
@@ -87,7 +87,7 @@ class zcConfigureFileReader {
 		if(!$this->fileLoaded()) return null;
 
 		// Extract the contents of the define
-		if(preg_match('|^\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|', $this->fileContent, $matches)) {
+		if(preg_match('|^\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|m', $this->fileContent, $matches)) {
 			return $matches[1];
 		}
 		return null;


### PR DESCRIPTION
The problem was that the configure.php file would be loaded as a contigous string, and the regex was trying to anchor at the start of the string.

Need to enable mult-line mode in regex