### PR TITLE
Indirect-expression fixes for PHP7

### DIFF
--- a/includes/classes/ajax/zcAjaxPayment.php
+++ b/includes/classes/ajax/zcAjaxPayment.php
@@ -160,23 +160,23 @@ class zcAjaxPayment extends base
       }
     }
 
-    if (isset ($$_SESSION['payment']->form_action_url)) {
-      $form_action_url = $$_SESSION['payment']->form_action_url;
+    if (isset (${$_SESSION['payment']}->form_action_url)) {
+      $form_action_url = ${$_SESSION['payment']}->form_action_url;
     } else {
       $form_action_url = zen_href_link (FILENAME_CHECKOUT_FLOW, 'step=process', 'SSL');
     }
 
     // if shipping-edit button should be overridden, do so
     $editShippingButtonLink = zen_href_link (FILENAME_CHECKOUT_SHIPPING, '', 'SSL');
-    if (method_exists ($$_SESSION['payment'], 'alterShippingEditButton')) {
-      $theLink = $$_SESSION['payment']->alterShippingEditButton ();
+    if (method_exists (${$_SESSION['payment']}, 'alterShippingEditButton')) {
+      $theLink = ${$_SESSION['payment']}->alterShippingEditButton ();
       if ($theLink)
         $editShippingButtonLink = $theLink;
     }
     // deal with billing address edit button
     $flagDisablePaymentAddressChange = false;
-    if (isset ($$_SESSION['payment']->flagDisablePaymentAddressChange)) {
-      $flagDisablePaymentAddressChange = $$_SESSION['payment']->flagDisablePaymentAddressChange;
+    if (isset (${$_SESSION['payment']}->flagDisablePaymentAddressChange)) {
+      $flagDisablePaymentAddressChange = ${$_SESSION['payment']}->flagDisablePaymentAddressChange;
     }
 
     $current_page_base = FILENAME_CHECKOUT_CONFIRMATION;

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -390,9 +390,9 @@ class order extends base {
     //print_r($GLOBALS);
     //echo $_SESSION['payment'];
     /*
-    // this is set above to the module filename it should be set to the module title like Check/Money Order rather than moneyorder
-    if (isset($$_SESSION['payment']) && is_object($$_SESSION['payment'])) {
-    $this->info['payment_method'] = $$_SESSION['payment']->title;
+    // this is set above to the module filename it should be set to the module title like Checks/Money Order rather than moneyorder
+    if (isset(${$_SESSION['payment']}) && is_object(${$_SESSION['payment']})) {
+    $this->info['payment_method'] = ${$_SESSION['payment']}->title;
     }
     */
 

--- a/includes/library/zencart/listingBox/src/DerivedItemManager.php
+++ b/includes/library/zencart/listingBox/src/DerivedItemManager.php
@@ -38,7 +38,7 @@ class DerivedItemManager
      */
     protected function getDerivedItemResult($derivedItem, $resultItem)
     {
-        $result = $this->$derivedItem ['handler']($resultItem);
+        $result = $this->{$derivedItem['handler']}($resultItem);
         return $result;
     }
 

--- a/includes/library/zencart/listingBox/src/formatters/TabularCustom.php
+++ b/includes/library/zencart/listingBox/src/formatters/TabularCustom.php
@@ -42,7 +42,7 @@ class TabularCustom extends AbstractFormatter implements FormatterInterface
                 );
                 if (isset($parameters ['formatter'])) {
                     $rowEntry = array(
-                        'value' => {$parameters['formatter']}(array(
+                        'value' => $parameters ['formatter'](array(
                             'item' => $item,
                             'field' => $field
                         )),

--- a/includes/library/zencart/listingBox/src/formatters/TabularCustom.php
+++ b/includes/library/zencart/listingBox/src/formatters/TabularCustom.php
@@ -42,7 +42,7 @@ class TabularCustom extends AbstractFormatter implements FormatterInterface
                 );
                 if (isset($parameters ['formatter'])) {
                     $rowEntry = array(
-                        'value' => $parameters ['formatter'](array(
+                        'value' => {$parameters['formatter']}(array(
                             'item' => $item,
                             'field' => $field
                         )),

--- a/includes/modules/pages/checkout_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_confirmation/header_php.php
@@ -87,7 +87,7 @@ if ($credit_covers) {
 
 $payment_modules = new payment($_SESSION['payment']);
 $payment_modules->update_status();
-if ( ($_SESSION['payment'] == '' || !is_object($$_SESSION['payment']) ) && $credit_covers === FALSE) {
+if ( ($_SESSION['payment'] == '' || !is_object(${$_SESSION['payment']}) ) && $credit_covers === FALSE) {
   $messageStack->add_session('checkout_payment', ERROR_NO_PAYMENT_MODULE_SELECTED, 'error');
 }
 
@@ -146,22 +146,22 @@ if ($_SESSION['cc_id']) {
   }
 }
 
-if (isset($$_SESSION['payment']->form_action_url)) {
-  $form_action_url = $$_SESSION['payment']->form_action_url;
+if (isset(${$_SESSION['payment']}->form_action_url)) {
+  $form_action_url = ${$_SESSION['payment']}->form_action_url;
 } else {
   $form_action_url = zen_href_link(FILENAME_CHECKOUT_PROCESS, '', 'SSL');
 }
 
 // if shipping-edit button should be overridden, do so
 $editShippingButtonLink = zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL');
-if (method_exists($$_SESSION['payment'], 'alterShippingEditButton')) {
-  $theLink = $$_SESSION['payment']->alterShippingEditButton();
+if (method_exists(${$_SESSION['payment']}, 'alterShippingEditButton')) {
+  $theLink = ${$_SESSION['payment']}->alterShippingEditButton();
   if ($theLink) $editShippingButtonLink = $theLink;
 }
 // deal with billing address edit button
 $flagDisablePaymentAddressChange = false;
-if (isset($$_SESSION['payment']->flagDisablePaymentAddressChange)) {
-  $flagDisablePaymentAddressChange = $$_SESSION['payment']->flagDisablePaymentAddressChange;
+if (isset(${$_SESSION['payment']}->flagDisablePaymentAddressChange)) {
+  $flagDisablePaymentAddressChange = ${$_SESSION['payment']}->flagDisablePaymentAddressChange;
 }
 
 

--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: header_php.php 18697 2011-05-04 14:35:20Z wilt $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.6.0 $
  */
 // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_HEADER_START_CHECKOUT_SHIPPING');
@@ -220,8 +220,8 @@ if (isset($_SESSION['cart']->cartID)) {
 
   // if shipping-edit button should be overridden, do so
   $editShippingButtonLink = zen_href_link(FILENAME_CHECKOUT_SHIPPING_ADDRESS, '', 'SSL');
-  if (isset($_SESSION['payment']) && method_exists($$_SESSION['payment'], 'alterShippingEditButton')) {
-    $theLink = $$_SESSION['payment']->alterShippingEditButton();
+  if (isset($_SESSION['payment']) && method_exists(${$_SESSION['payment']}, 'alterShippingEditButton')) {
+    $theLink = ${$_SESSION['payment']}->alterShippingEditButton();
     if ($theLink) {
       $editShippingButtonLink = $theLink;
       $displayAddressEdit = true;


### PR DESCRIPTION
These are related to use of $$foo['element'] which need to add the {braces} for specificity