### PR TITLE
CHANGE-465 - Add more notifier hooks to dynamic metatags generator module

### DIFF
--- a/includes/modules/meta_tags.php
+++ b/includes/modules/meta_tags.php
@@ -8,11 +8,13 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: meta_tags.php drbyte  Modified in v1.6.0 $
  */
+$meta_tags_over_ride = false;
+$metatag_page_name = $current_page_base;
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 // This should be first line of the script:
-$zco_notifier->notify('NOTIFY_MODULE_START_META_TAGS');
+$zco_notifier->notify('NOTIFY_MODULE_START_META_TAGS', $current_page_base, $metatag_page_name, $meta_tags_over_ride);
 
 // Add tertiary section to site tagline
 if (strlen(SITE_TAGLINE) > 1) {
@@ -20,10 +22,8 @@ if (strlen(SITE_TAGLINE) > 1) {
 } else {
   define('TAGLINE', '');
 }
-
 $review_on = "";
 $keywords_string_metatags = "";
-$meta_tags_over_ride = false;
 if (!defined('METATAGS_DIVIDER')) define('METATAGS_DIVIDER', ', ');
 
 // Get all top category names for use with web site keywords
@@ -37,14 +37,14 @@ $zco_notifier->notify('NOTIFY_MODULE_META_TAGS_BUILDKEYWORDS', CUSTOM_KEYWORDS, 
 define('KEYWORDS', str_replace('"','',zen_clean_html($keywords_string_metatags) . CUSTOM_KEYWORDS));
 
 // if per-page metatags overrides have been defined, use those, otherwise use usual defaults:
-if ($current_page_base != 'index') {
-  if (defined('META_TAG_TITLE_' . strtoupper($current_page_base))) define('META_TAG_TITLE', constant('META_TAG_TITLE_' . strtoupper($current_page_base)));
-  if (defined('META_TAG_DESCRIPTION_' . strtoupper($current_page_base))) define('META_TAG_DESCRIPTION', constant('META_TAG_DESCRIPTION_' . strtoupper($current_page_base)));
-  if (defined('META_TAG_KEYWORDS_' . strtoupper($current_page_base))) define('META_TAG_KEYWORDS', constant('META_TAG_KEYWORDS_' . strtoupper($current_page_base)));
+if ($metatag_page_name != 'index') {
+  if (defined('META_TAG_TITLE_' . strtoupper($metatag_page_name))) define('META_TAG_TITLE', constant('META_TAG_TITLE_' . strtoupper($metatag_page_name)));
+  if (defined('META_TAG_DESCRIPTION_' . strtoupper($metatag_page_name))) define('META_TAG_DESCRIPTION', constant('META_TAG_DESCRIPTION_' . strtoupper($metatag_page_name)));
+  if (defined('META_TAG_KEYWORDS_' . strtoupper($metatag_page_name))) define('META_TAG_KEYWORDS', constant('META_TAG_KEYWORDS_' . strtoupper($metatag_page_name)));
 }
 
 // Get different meta tag values depending on main_page values
-switch ($_GET['main_page']) {
+switch ($metatag_page_name) {
   case 'advanced_search':
   case 'account_edit':
   case 'account_history':
@@ -323,15 +323,15 @@ switch ($_GET['main_page']) {
     $metatags_title = (defined('NAVBAR_TITLE') ? NAVBAR_TITLE . PRIMARY_SECTION : '') . TITLE . TAGLINE;
     $metatags_description = TITLE . (defined('NAVBAR_TITLE') ? PRIMARY_SECTION . NAVBAR_TITLE : '') . SECONDARY_SECTION . KEYWORDS;
     $metatags_keywords = KEYWORDS . METATAGS_DIVIDER . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '');
-    $zco_notifier->notify('NOTIFY_MODULE_META_TAGS_UNSPECIFIEDPAGE', $current_page_base, $meta_tags_over_ride, $metatags_title, $metatags_description, $metatags_keywords);
+    $zco_notifier->notify('NOTIFY_MODULE_META_TAGS_UNSPECIFIEDPAGE', $current_page_base, $metatag_page_name, $meta_tags_over_ride, $metatags_title, $metatags_description, $metatags_keywords);
     if (false===$meta_tags_over_ride) {
-  define('META_TAG_TITLE', (defined('NAVBAR_TITLE') ? NAVBAR_TITLE . PRIMARY_SECTION : '') . TITLE . TAGLINE);
-  define('META_TAG_DESCRIPTION', TITLE . PRIMARY_SECTION . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '' ) . SECONDARY_SECTION . KEYWORDS);
-  define('META_TAG_KEYWORDS', KEYWORDS . METATAGS_DIVIDER . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '' ) );
-}
+      define('META_TAG_TITLE', (defined('NAVBAR_TITLE') ? NAVBAR_TITLE . PRIMARY_SECTION : '') . TITLE . TAGLINE);
+      define('META_TAG_DESCRIPTION', TITLE . PRIMARY_SECTION . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '' ) . SECONDARY_SECTION . KEYWORDS);
+      define('META_TAG_KEYWORDS', KEYWORDS . METATAGS_DIVIDER . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '' ) );
+    }
 }
 
-$zco_notifier->notify('NOTIFY_MODULE_META_TAGS_OVERRIDE', array(), $meta_tags_over_ride, $metatags_title, $metatags_description, $metatags_keywords);
+$zco_notifier->notify('NOTIFY_MODULE_META_TAGS_OVERRIDE', $metatag_page_name, $meta_tags_over_ride, $metatags_title, $metatags_description, $metatags_keywords);
 
 // meta tags override due to 404, missing products_id, cPath or other EOF issues
 if ($meta_tags_over_ride == true) {

--- a/includes/modules/meta_tags.php
+++ b/includes/modules/meta_tags.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: meta_tags.php 11202 2008-11-23 09:18:34Z drbyte  Modified in v1.6.0 $
+ * @version $Id: meta_tags.php drbyte  Modified in v1.6.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -33,6 +33,7 @@ while (!$keywords_metatags->EOF) {
   $keywords_string_metatags .= zen_clean_html($keywords_metatags->fields['categories_name']) . METATAGS_DIVIDER;
   $keywords_metatags->MoveNext();
 }
+$zco_notifier->notify('NOTIFY_MODULE_META_TAGS_BUILDKEYWORDS', CUSTOM_KEYWORDS, $keywords_string_metatags);
 define('KEYWORDS', str_replace('"','',zen_clean_html($keywords_string_metatags) . CUSTOM_KEYWORDS));
 
 // if per-page metatags overrides have been defined, use those, otherwise use usual defaults:
@@ -319,16 +320,24 @@ switch ($_GET['main_page']) {
   if (defined('META_TAG_KEYWORDS_EZPAGE_'.$ezpage_id)) define('META_TAG_KEYWORDS', constant('META_TAG_KEYWORDS_EZPAGE_'.$ezpage_id));
 // NO "break" here. Allow defaults if not overridden at the per-page level
   default:
+    $metatags_title = (defined('NAVBAR_TITLE') ? NAVBAR_TITLE . PRIMARY_SECTION : '') . TITLE . TAGLINE;
+    $metatags_description = TITLE . (defined('NAVBAR_TITLE') ? PRIMARY_SECTION . NAVBAR_TITLE : '') . SECONDARY_SECTION . KEYWORDS;
+    $metatags_keywords = KEYWORDS . METATAGS_DIVIDER . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '');
+    $zco_notifier->notify('NOTIFY_MODULE_META_TAGS_UNSPECIFIEDPAGE', $current_page_base, $meta_tags_over_ride, $metatags_title, $metatags_description, $metatags_keywords);
+    if (false===$meta_tags_over_ride) {
   define('META_TAG_TITLE', (defined('NAVBAR_TITLE') ? NAVBAR_TITLE . PRIMARY_SECTION : '') . TITLE . TAGLINE);
   define('META_TAG_DESCRIPTION', TITLE . PRIMARY_SECTION . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '' ) . SECONDARY_SECTION . KEYWORDS);
   define('META_TAG_KEYWORDS', KEYWORDS . METATAGS_DIVIDER . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : '' ) );
 }
+}
+
+$zco_notifier->notify('NOTIFY_MODULE_META_TAGS_OVERRIDE', array(), $meta_tags_over_ride, $metatags_title, $metatags_description, $metatags_keywords);
 
 // meta tags override due to 404, missing products_id, cPath or other EOF issues
 if ($meta_tags_over_ride == true) {
-  define('META_TAG_TITLE', (defined('NAVBAR_TITLE') ? NAVBAR_TITLE . PRIMARY_SECTION : '') . TITLE . TAGLINE);
-  define('META_TAG_DESCRIPTION', TITLE . (defined('NAVBAR_TITLE') ? PRIMARY_SECTION . NAVBAR_TITLE : '') . SECONDARY_SECTION . KEYWORDS);
-  define('META_TAG_KEYWORDS', KEYWORDS . METATAGS_DIVIDER . (defined('NAVBAR_TITLE') ? NAVBAR_TITLE : ''));
+  define('META_TAG_TITLE', $metatags_title);
+  define('META_TAG_DESCRIPTION', $metatags_description);
+  define('META_TAG_KEYWORDS', $metatags_keywords);
 }
 
 // This should be last line of the script:


### PR DESCRIPTION
These hooks can be used in various ways:
- As in previous versions, hooking `NOTIFY_MODULE_START_META_TAGS` allows one to completely intercept the default metatags generation altogether
- `NOTIFY_MODULE_META_TAGS_BUILDKEYWORDS` allows overriding of just the dynamic generation of keywords
- `NOTIFY_MODULE_META_TAGS_UNSPECIFIEDPAGE` allows the injection of metatags for pages that don't have built-in generation logic in the default module

Also allows an observer on `NOTIFY_MODULE_START_META_TAGS` to change the value of `$metatag_page_name` ... which could force the usual rules to be bypassed (and thus trigger "default"), which can then be intercepted by `NOTIFY_MODULE_META_TAGS_UNSPECIFIEDPAGE` if necessary, to set specific values.