### PR TITLE
Fix for: zen_draw_date_selector "times out" in 2018

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2010,7 +2010,7 @@ while (!$chk_sale_categories_all->EOF) {
     }
     $date_selector .= '</select>';
     $date_selector .= '<select name="'. $prefix .'_year">';
-    for ($i=2001;$i<2019;$i++){
+    for ($i=date('Y')-5; $i<date('Y')+11; $i++) {
       $date_selector .= '<option value="' . $i . '"';
       if ($i==$year) $date_selector .= 'selected';
       $date_selector .= '>' . $i . '</option>';

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2010,7 +2010,7 @@ while (!$chk_sale_categories_all->EOF) {
     }
     $date_selector .= '</select>';
     $date_selector .= '<select name="'. $prefix .'_year">';
-    for ($i=date('Y')-5; $i<date('Y')+11; $i++) {
+    for ($i = date('Y') - 5, $j = date('Y') + 11; $i < $j; $i++) {
       $date_selector .= '<option value="' . $i . '"';
       if ($i==$year) $date_selector .= 'selected';
       $date_selector .= '>' . $i . '</option>';


### PR DESCRIPTION
Ref: https://www.zen-cart.com/showthread.php?219015

Now the default range is 5 years "ago" until 10 years "in future"