### PR TITLE
Inline sanitizing of input variables (part of previous patch)

### DIFF
--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -3,12 +3,12 @@
  * init_sanitize
  *
  * @package initSystem
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Fri Mar 7 21:54:17 2014 +0000 Modified in v1.5.3 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 $saniGroup1 = array('action', 'add_products_id', 'attribute_id', 'attribute_page', 'attributes_id', 'banner', 'bID', 'box_name', 'build_cat', 'came_from', 'categories_update_id', 'cID', 'cid', 'configuration_key_lookup', 'copy_attributes',
-'cpage', 'cPath', 'current_category_id', 'current', 'customer', 'debug', 'debug2', 'debug3', 'define_it', 'download_reset_off', 'download_reset_on', 'end_date', 'ezID', 'fID', 'filename', 'flag',
+'cpage', 'cPath', 'current_category_id', 'current', 'current_master_categories_id', 'customer', 'debug', 'debug2', 'debug3', 'define_it', 'download_reset_off', 'download_reset_on', 'end_date', 'ezID', 'fID', 'filename', 'flag',
 'flagbanners_on_ssl', 'flagbanners_open_new_windows', 'gID', 'gid', 'global', 'go_back', 'id', 'info', 'ipnID', 'keepslashes', 'layout_box_name', 'lID', 'list_order', 'language', 'lng_id', 'lngdir', 'mail_sent_to', 'manual',
 'master_category', 'mID', 'mode', 'module', 'month', 'na', 'nID', 'nogrants', 'ns', 'number_of_uploads', 'oID', 'oldaction', 'option_id', 'option_order_by', 'option_page', 'options_id_from', 'options_id', 'order_by',
 'order', 'origin', 'p', 'padID', 'page', 'pages_id', 'payment_status', 'paypal_ipn_sort_order', 'pID', 'ppage', 'product_type', 'products_filter_name_model', 'products_filter', 'products_id',

--- a/admin/includes/modules/category_product_listing.php
+++ b/admin/includes/modules/category_product_listing.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Wed Mar 12 12:53:44 2014 +0000 Modified in v1.5.3 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -33,7 +33,8 @@ if (!isset($_SESSION['display_categories_dropdown'])) {
       echo '<a href="' . zen_href_link(FILENAME_CATEGORIES) . '">' . zen_image_button('button_reset.gif', IMAGE_RESET) . '</a>&nbsp;&nbsp;';
     }
     echo HEADING_TITLE_SEARCH_DETAIL . ' ' . zen_draw_input_field('search', '', ($action == '' ? 'autofocus="autofocus"' : '')) . zen_hide_session_id();
-    if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
+    if (isset($_GET['search']) && zen_not_null($_GET['search'], zen_output_string_protected($_GET['search']))) {
+
       $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
       echo '<br />' . TEXT_INFO_SEARCH_DETAIL_FILTER . zen_output_string_protected($_GET['search']);
     }

--- a/admin/includes/modules/document_general/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_general/preview_info_meta_tags.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Tue Aug 7 15:42:16 2012 +0100 Modified in v1.5.1 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -55,7 +55,7 @@ if (!defined('IS_ADMIN_FLAG')) {
             </td>
 <!-- // not used for documents
             <td class="main" valign="top">
-               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
+               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? zen_output_string_protected($pInfo->products_model) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
                <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
@@ -67,15 +67,15 @@ if (!defined('IS_ADMIN_FLAG')) {
 
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED) ; ?></td>
+            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? zen_output_string_protected($pInfo->metatags_title) : TEXT_META_EXCLUDED) ; ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_keywords); ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_description); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/includes/modules/document_product/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_product/preview_info_meta_tags.php
@@ -1,14 +1,15 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Tue Aug 7 15:42:16 2012 +0100 Modified in v1.5.1 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
+
     if (zen_not_null($_POST)) {
       $pInfo = new objectInfo($_POST);
       $metatags_title = $_POST['metatags_title'];
@@ -53,7 +54,7 @@ if (!defined('IS_ADMIN_FLAG')) {
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
-               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
+               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? zen_output_string_protected($pInfo->products_model) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
                <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
@@ -64,15 +65,15 @@ if (!defined('IS_ADMIN_FLAG')) {
 
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED) ; ?></td>
+            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? zen_output_string_protected($pInfo->metatags_title) : TEXT_META_EXCLUDED) ; ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_keywords); ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_description); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/includes/modules/product/preview_info_meta_tags.php
+++ b/admin/includes/modules/product/preview_info_meta_tags.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Tue Aug 7 15:42:16 2012 +0100 Modified in v1.5.1 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -54,7 +54,7 @@ if (!defined('IS_ADMIN_FLAG')) {
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
-               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
+               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? zen_output_string_protected($pInfo->products_model) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
                <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
@@ -65,15 +65,15 @@ if (!defined('IS_ADMIN_FLAG')) {
 
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED) ; ?></td>
+            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? zen_output_string_protected($pInfo->metatags_title) : TEXT_META_EXCLUDED) ; ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_keywords); ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_description); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Tue Aug 7 15:42:16 2012 +0100 Modified in v1.5.1 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -53,7 +53,7 @@ if (!defined('IS_ADMIN_FLAG')) {
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
-               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
+               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? zen_output_string_protected($pInfo->products_model) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
                <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
@@ -64,15 +64,15 @@ if (!defined('IS_ADMIN_FLAG')) {
 
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED) ; ?></td>
+            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? zen_output_string_protected($pInfo->metatags_title) : TEXT_META_EXCLUDED) ; ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_keywords); ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_description); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/includes/modules/product_music/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_music/preview_info_meta_tags.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2012 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Tue Aug 7 15:42:16 2012 +0100 Modified in v1.5.1 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -53,7 +53,7 @@ if (!defined('IS_ADMIN_FLAG')) {
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
-               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
+               <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? zen_output_string_protected($pInfo->products_model) : TEXT_META_EXCLUDED); ?>
             </td>
             <td class="main" valign="top">
                <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
@@ -64,15 +64,15 @@ if (!defined('IS_ADMIN_FLAG')) {
 
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED) ; ?></td>
+            <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? zen_output_string_protected($pInfo->metatags_title) : TEXT_META_EXCLUDED) ; ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_keywords); ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
-            <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
+            <td class="main" colspan="3"><?php echo zen_output_string_protected($pInfo->metatags_description); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2015 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Thu Oct 24 21:13:46 2013 +0100 Modified in v1.5.2 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 
   require('includes/application_top.php');
@@ -355,7 +355,7 @@ function array_minus_array($a, $b) {
       case 'update_product':
         $zv_check_master_categories_id = 'true';
         $new_categories_sort_array[] = $_POST['current_master_categories_id'];
-        $current_master_categories_id = $_POST['current_master_categories_id'];
+        $current_master_categories_id = (int)$_POST['current_master_categories_id'];
 
         // set the linked products master_categories_id product(s)
         for ($i=0, $n=sizeof($_POST['categories_add']); $i<$n; $i++) {
@@ -639,7 +639,7 @@ if ($_GET['products_filter'] != '') {
       echo '  <td class="dataTableContent" align="right">' . $categories_list->fields['categories_id'] . '</td>' . "\n";
       if ($product_to_copy->fields['master_categories_id'] == $categories_list->fields['categories_id']) {
 //        echo '  <td class="dataTableContent" align="left">' . ($selected ? '<strong>' : '') . $zc_categories_checkbox . '&nbsp;' . $categories_list->fields['categories_name'] . ($selected ? '</strong>' : '') . '&nbsp;' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_LINKED) . '</td>' . "\n";
-        echo '  <td class="dataTableContent" align="left">' . '&nbsp;' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_LINKED) . '&nbsp;' . $categories_list->fields['categories_name'] . zen_draw_hidden_field('current_master_categories_id', $categories_list->fields['categories_id']) . '</td>' . "\n";
+        echo '  <td class="dataTableContent" align="left">' . '&nbsp;' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_LINKED) . '&nbsp;' . $categories_list->fields['categories_name'] . zen_draw_hidden_field('current_master_categories_id', (int)$categories_list->fields['categories_id']) . '</td>' . "\n";
       } else {
         echo '  <td class="dataTableContent" align="left">' . ($selected ? '<strong>' : '') . $zc_categories_checkbox . '&nbsp;' . $categories_list->fields['categories_name'] . ($selected ? '</strong>' : '') . '</td>' . "\n";
       }


### PR DESCRIPTION
These input sanitizations are largely covered by the more aggressive `xss` patch from earlier this week, but these edits place the hardening directly into the places where some of the addressed concerns occur.