### PR TITLE
Add PayPal's temporary security endpoint test URL to curltester

### DIFF
--- a/extras/curltester.php
+++ b/extras/curltester.php
@@ -89,6 +89,11 @@ doCurlTest('https://api-3t.paypal.com/nvp');
 echo 'Connecting to PayPal Express/Pro Sandbox ...<br>';
 doCurlTest('https://api-3t.sandbox.paypal.com/nvp');
 
+if (time() < mktime(0, 0, 0, 3, 1, 2016)) {
+  echo 'Connecting to PayPal SECURITY ENDPOINT 2016 Sandbox ...<br>';
+  doCurlTest('https://test-api-3t.sandbox.paypal.com/nvp');
+}
+
 echo 'Connecting to PayPal Payflowpro Server ...<br>';
 doCurlTest('https://payflowpro.paypal.com/transaction');
 


### PR DESCRIPTION
This is only valid until end of Feb 2016