### PR TITLE
Remove deprecated `language=javascript`

### DIFF
--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -120,7 +120,7 @@ class payment extends base {
   function javascript_validation() {
     $js = '';
     if (is_array($this->modules) && sizeof($this->selection()) > 0) {
-      $js = '<script language="javascript"  type="text/javascript"><!-- ' . "\n" .
+      $js = '<script type="text/javascript"><!-- ' . "\n" .
       'function check_form() {' . "\n" .
       '  var error = 0;' . "\n" .
       '  var error_message = "' . JS_ERROR . '";' . "\n" .

--- a/includes/form_check.js.php
+++ b/includes/form_check.js.php
@@ -9,7 +9,7 @@
  * @version $Id: form_check.js.php 17018 2010-07-27 07:25:41Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/additional_images.php
+++ b/includes/modules/additional_images.php
@@ -95,7 +95,7 @@ if ($num_images) {
     $large_link = zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large);
 
     // Link Preparation:
-    $script_link = '<script language="javascript" type="text/javascript"><!--' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="javascript:popupWindow(\\\'' . str_replace($products_image_large, urlencode(addslashes($products_image_large)), $large_link) . '\\\')">' . $thumb_slashes . '<br />' . TEXT_CLICK_TO_ENLARGE . '</a>' : $thumb_slashes) . '\');' . "\n" . '//--></script>';
+    $script_link = '<script type="text/javascript"><!--' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="javascript:popupWindow(\\\'' . str_replace($products_image_large, urlencode(addslashes($products_image_large)), $large_link) . '\\\')">' . $thumb_slashes . '<br />' . TEXT_CLICK_TO_ENLARGE . '</a>' : $thumb_slashes) . '\');' . "\n" . '//--></script>';
 
     $noscript_link = '<noscript>' . ($flag_display_large ? '<a href="' . zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large) . '" target="_blank">' . $thumb_regular . '<br /><span class="imgLinkAdditional">' . TEXT_CLICK_TO_ENLARGE . '</span></a>' : $thumb_regular ) . '</noscript>';
 

--- a/includes/modules/pages/account/jscript_main.php
+++ b/includes/modules/pages/account/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script language="javascript"  type="text/javascript"><!--
+<script type="text/javascript"><!--
 function rowOverEffect(object) {
   if (object.className == 'moduleRow') object.className = 'moduleRowOver';
 }

--- a/includes/modules/pages/account_edit/jscript_form_check.php
+++ b/includes/modules/pages/account_edit/jscript_form_check.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_form_check.php 17018 2010-07-27 07:25:41Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/pages/account_history_info/jscript_main.php
+++ b/includes/modules/pages/account_history_info/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 4942 2006-11-17 06:21:37Z ajeh $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 
 function couponpopupWindow(url) {
   window.open(url,'couponpopupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=320,screenX=150,screenY=150,top=150,left=150')

--- a/includes/modules/pages/account_newsletters/jscript_main.php
+++ b/includes/modules/pages/account_newsletters/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 4274 2006-08-26 03:16:53Z drbyte $
  */
 ?>
-<script language="javascript"  type="text/javascript"><!--
+<script type="text/javascript"><!--
 function checkBox(object) {
   document.account_newsletter.elements[object].checked = !document.account_newsletter.elements[object].checked;
 }

--- a/includes/modules/pages/account_password/jscript_form_check.php
+++ b/includes/modules/pages/account_password/jscript_form_check.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_form_check.php 17014 2010-07-27 06:17:53Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/pages/address_book/jscript_main.php
+++ b/includes/modules/pages/address_book/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function rowOverEffect(object) {
   if (object.className == 'moduleRow') object.className = 'moduleRowOver';
 }

--- a/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: jscript_addr_pulldowns.php 4830 2006-10-24 21:58:27Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates

--- a/includes/modules/pages/address_book_process/jscript_main.php
+++ b/includes/modules/pages/address_book_process/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 17018 2010-07-27 07:25:41Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/pages/advanced_search/jscript_main.php
+++ b/includes/modules/pages/advanced_search/jscript_main.php
@@ -20,8 +20,8 @@
 // $Id: jscript_main.php 345 2004-09-27 19:59:38Z wilt $
 //
 ?>
-<script language="javascript" src="includes/general.js" type="text/javascript"></script>
-<script language="javascript" type="text/javascript"><!--
+<script src="includes/general.js" type="text/javascript"></script>
+<script type="text/javascript"><!--
 function check_form() {
   var error_message = "<?php echo JS_ERROR; ?>";
   var error_found = false;

--- a/includes/modules/pages/checkout_confirmation/jscript_main.php
+++ b/includes/modules/pages/checkout_confirmation/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 15536 2010-02-20 06:11:54Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var submitter = null;
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=320,screenX=150,screenY=150,top=150,left=150')

--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -9,7 +9,7 @@
  * @version GIT: $Id: Author: Ian Wilson   Modified in v1.5.4 $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 var submitter = null;
 

--- a/includes/modules/pages/checkout_payment_address/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/checkout_payment_address/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: jscript_addr_pulldowns.php 4830 2006-10-24 21:58:27Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates

--- a/includes/modules/pages/checkout_payment_address/jscript_main.php
+++ b/includes/modules/pages/checkout_payment_address/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 17016 2010-07-27 06:54:42Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/pages/checkout_shipping_address/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/checkout_shipping_address/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: jscript_addr_pulldowns.php 4830 2006-10-24 21:58:27Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates

--- a/includes/modules/pages/checkout_shipping_address/jscript_main.php
+++ b/includes/modules/pages/checkout_shipping_address/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 17018 2010-07-27 07:25:41Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/pages/create_account/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/create_account/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: jscript_addr_pulldowns.php 4830 2006-10-24 21:58:27Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates

--- a/includes/modules/pages/create_account/jscript_form_check.php
+++ b/includes/modules/pages/create_account/jscript_form_check.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_form_check.php 17018 2010-07-27 07:25:41Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/pages/document_general_info/jscript_main.php
+++ b/includes/modules/pages/document_general_info/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }

--- a/includes/modules/pages/document_product_info/jscript_main.php
+++ b/includes/modules/pages/document_product_info/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }

--- a/includes/modules/pages/login/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/login/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: jscript_addr_pulldowns.php 4830 2006-10-24 21:58:27Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates

--- a/includes/modules/pages/login/jscript_form_check.php
+++ b/includes/modules/pages/login/jscript_form_check.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_form_check.php 17018 2010-07-27 07:25:41Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var selected;
 
 function check_form_optional(form_name) {

--- a/includes/modules/pages/login/jscript_main.php
+++ b/includes/modules/pages/login/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function session_win() {
   window.open("<?php echo zen_href_link(FILENAME_INFO_SHOPPING_CART); ?>","info_shopping_cart","height=460,width=430,toolbar=no,statusbar=no,scrollbars=yes").focus();
 }

--- a/includes/modules/pages/popup_coupon_help/jscript_main.php
+++ b/includes/modules/pages/popup_coupon_help/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var i=0;
 function resize() {
   if (navigator.appName == 'Netscape') i=10;

--- a/includes/modules/pages/popup_cvv_help/jscript_main.php
+++ b/includes/modules/pages/popup_cvv_help/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var i=0;
 function resize() {
   if (navigator.appName == 'Netscape') i=40;

--- a/includes/modules/pages/popup_image/jscript_main.php
+++ b/includes/modules/pages/popup_image/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 3126 2006-03-07 03:09:40Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var i=0;
 function resize() {
   i=0;

--- a/includes/modules/pages/popup_image_additional/jscript_main.php
+++ b/includes/modules/pages/popup_image_additional/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: jscript_main.php 3126 2006-03-07 03:09:40Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var i=0;
 function resize() {
   i=0;

--- a/includes/modules/pages/popup_search_help/jscript_main.php
+++ b/includes/modules/pages/popup_search_help/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var i=0;
 function resize() {
   if (navigator.appName == 'Netscape') i=40;

--- a/includes/modules/pages/popup_shipping_estimator/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/popup_shipping_estimator/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: jscript_addr_pulldowns.php 5351 2006-12-22 21:01:55Z drbyte $
  */
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates

--- a/includes/modules/pages/product_free_shipping_info/jscript_main.php
+++ b/includes/modules/pages/product_free_shipping_info/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }

--- a/includes/modules/pages/product_info/jscript_main.php
+++ b/includes/modules/pages/product_info/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }

--- a/includes/modules/pages/product_music_info/jscript_main.php
+++ b/includes/modules/pages/product_music_info/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }

--- a/includes/modules/pages/product_reviews/jscript_main.php
+++ b/includes/modules/pages/product_reviews/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }

--- a/includes/modules/pages/product_reviews_info/jscript_main.php
+++ b/includes/modules/pages/product_reviews_info/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }

--- a/includes/modules/pages/product_reviews_write/jscript_main.php
+++ b/includes/modules/pages/product_reviews_write/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 var form = "";
 var submitted = false;
 var error = false;

--- a/includes/modules/pages/shopping_cart/jscript_main.php
+++ b/includes/modules/pages/shopping_cart/jscript_main.php
@@ -20,13 +20,11 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script language="javascript" src="includes/general.js" type="text/javascript"></script>
-<script language="javascript" type="text/javascript"><!--
+<script src="includes/general.js" type="text/javascript"></script>
+<script type="text/javascript"><!--
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=550,height=550,screenX=150,screenY=100,top=100,left=150')
 }
-//--></script>
-<script language="javascript" type="text/javascript"><!--
 function session_win() {
   window.open("<?php echo zen_href_link(FILENAME_INFO_SHOPPING_CART); ?>","info_shopping_cart","height=460,width=430,toolbar=no,statusbar=no,scrollbars=yes").focus();
 }

--- a/includes/modules/shipping_estimator.php
+++ b/includes/modules/shipping_estimator.php
@@ -26,7 +26,7 @@ if ($current_page_base != 'popup_shipping_estimator') {
 ?>
 <!-- shipping_estimator //-->
 
-<script language="javascript" type="text/javascript">
+<script type="text/javascript">
 function shipincart_submit(){
   document.estimator.submit();
   return false;
@@ -286,5 +286,5 @@ if ($_SESSION['cart']->count_contents() > 0) {
 <?php
 }
 ?>
-<script type="text/javascript" language="javascript">update_zone(document.estimator); </script>
+<script type="text/javascript">update_zone(document.estimator); </script>
 <!-- shipping_estimator_eof //-->

--- a/includes/templates/responsive_classic/jscript/jscript_framework.php
+++ b/includes/templates/responsive_classic/jscript/jscript_framework.php
@@ -6,7 +6,7 @@
  * @version GIT: $Id: Author: Ian Wilson  New in v1.5.4 $
  */
 ?>
-<script>
+<script type="text/javascript">
 if (typeof zcJS == "undefined" || !zcJS) {
   window.zcJS = { name: 'zcJS', version: '0.1.0.0' };
 };

--- a/includes/templates/template_default/templates/tpl_modules_main_product_image.php
+++ b/includes/templates/template_default/templates/tpl_modules_main_product_image.php
@@ -11,7 +11,7 @@
 ?>
 <?php require(DIR_WS_MODULES . zen_get_module_directory(FILENAME_MAIN_PRODUCT_IMAGE)); ?>
 <div id="productMainImage" class="centeredContent back">
-<script language="javascript" type="text/javascript"><!--
+<script type="text/javascript"><!--
 document.write('<?php echo '<a href="javascript:popupWindow(\\\'' . zen_href_link(FILENAME_POPUP_IMAGE, 'pID=' . $_GET['products_id']) . '\\\')">' . zen_image(addslashes($products_image_medium), addslashes($products_name), MEDIUM_IMAGE_WIDTH, MEDIUM_IMAGE_HEIGHT) . '<br /><span class="imgLink">' . TEXT_CLICK_TO_ENLARGE . '</span></a>'; ?>');
 //--></script>
 <noscript>


### PR DESCRIPTION
... and add `type=text/javascript` for compatibility with both HTML5 and HTML4

NOTE: for upgraders, updating these files isn't urgent, but will reduce "validator" errors when doing site-inspections. Functionally, modern browsers will be happy either way.