### PR TITLE
Make validator links more versatile for https

### DIFF
--- a/includes/templates/responsive_classic/common/tpl_footer.php
+++ b/includes/templates/responsive_classic/common/tpl_footer.php
@@ -67,5 +67,5 @@ if (SHOW_FOOTER_IP == '1') {
 ?>
 
 <?php if (false || (isset($showValidatorLink) && $showValidatorLink == true)) { ?>
-<a href="https://validator.w3.org/nu/?doc=<?php echo urlencode('https://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'] . '&?&' . zen_session_name() . '=' . zen_session_id()); ?>" target="_blank">VALIDATOR</a>
+<a href="https://validator.w3.org/nu/?doc=<?php echo urlencode('http' . ($request_type == 'SSL' ? 's' : '') . '://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'] . (strstr($_SERVER['REQUEST_URI'], '?') ? '&' : '?') . zen_session_name() . '=' . zen_session_id()); ?>" target="_blank">VALIDATOR</a>
 <?php } ?>

--- a/includes/templates/template_default/common/tpl_footer.php
+++ b/includes/templates/template_default/common/tpl_footer.php
@@ -67,5 +67,5 @@ if (SHOW_FOOTER_IP == '1') {
 ?>
 
 <?php if (false || (isset($showValidatorLink) && $showValidatorLink == true)) { ?>
-<a href="https://validator.w3.org/check?uri=<?php echo urlencode('https://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'] . '&?&' . zen_session_name() . '=' . zen_session_id()); ?>" target="_blank">VALIDATOR</a>
+<a href="https://validator.w3.org/check?uri=<?php echo urlencode('http' . ($request_type == 'SSL' ? 's' : '') . '://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'] . (strstr($_SERVER['REQUEST_URI'], '?') ? '&' : '?') . zen_session_name() . '=' . zen_session_id()); ?>" target="_blank">VALIDATOR</a>
 <?php } ?>


### PR DESCRIPTION
Make validator links more versatile for https and not throw error on home page due to mismatched ?/& symbols