### PR TITLE
Display orders in Admin even if orders_status is invalid (with an alert)

### DIFF
--- a/admin/includes/languages/english/orders.php
+++ b/admin/includes/languages/english/orders.php
@@ -119,3 +119,5 @@ define('TEXT_COMMENTS_YES', 'Customer Comments - YES');
 define('TEXT_COMMENTS_NO', 'Customer Comments - NO');
 
 define('TEXT_CUSTOMER_LOOKUP', 'Lookup Customer');
+
+define('TEXT_INVALID_ORDER_STATUS', '<span class="alert">(Invalid Order Status)</span>');


### PR DESCRIPTION
Previously any orders whose `orders_status` value didn't match a value in the `orders_status` table would be excluded from display in the Admin.

This now includes those orders, along with an alert which informs the administrator that the order-status is invalid.

(As always, to fix an order in this condition, simply go into the order and do an update to a new order-status using the dropdown menu)