### PR TITLE
Log email errors with other PHP errors in /logs/ folder

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -5,7 +5,7 @@
  * Hooks into phpMailer class for actual email encoding and sending
  *
  * @package functions
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version GIT: $Id: Author: DrByte  Modified in v1.5.5 $
@@ -371,7 +371,9 @@
     } // end foreach loop thru possible multiple email addresses
     $zco_notifier->notify('NOTIFY_EMAIL_AFTER_SEND_ALL_SPECIFIED_ADDRESSES');
 
-    if (EMAIL_FRIENDLY_ERRORS=='false' && $ErrorInfo != '') die('<br /><br />Email Error: ' . $ErrorInfo);
+    if ($ErrorInfo != '') {
+      trigger_error('Email Error: ' . $ErrorInfo);
+    }
 
     return $ErrorInfo;
   }  // end function


### PR DESCRIPTION
Email errors will now be logged the same as any other PHP error, in the `/logs/` folder.

This could ultimately deprecate the `EMAIL_FRIENDLY_ERRORS` switch as this basically renders it moot.

Ref: https://www.zen-cart.com/showthread.php?219285-sending-order-emails