### PR TITLE
Null dates need to be passed as `null` instead of `'null'`

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -4,11 +4,11 @@
  * Class used for database abstraction to MySQL via mysqli
  *
  * @package classes
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @copyright Portions adapted from http://www.data-diggers.com/
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: Ian Wilson  Modified in v1.6.0 $
+ * @version GIT: $Id: Author: Ian Wilson  Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -440,6 +440,7 @@ class queryFactory extends base {
         return (int)$value;
       break;
       case 'string':
+        if (preg_match('/null/i', $value)) return 'null';
         if (isset($typeArray[1])) {
           $regexp = $typeArray[1];
         }
@@ -452,6 +453,7 @@ class queryFactory extends base {
         return '\'' . $this->prepare_input($value) . '\'';
       break;
       case 'date':
+        if (preg_match('/null/i', $value)) return 'null';
         return '\'' . $this->prepare_input($value) . '\'';
       break;
       case 'enum':


### PR DESCRIPTION
Null dates need to be passed as `null` instead of `'null'` 

Same with strings.

USAGE NOTE:  For BindVars, for `date` and `string` bindVarTypes, passed values of a string `null` (case-insensitive) will be converted to a literal MySQL `null` instead of treated as a string of the word `'null'`