### PR TITLE
Mc12345678 code for #270 - consolidate zen_db_output

### DIFF
--- a/admin/admin_activity.php
+++ b/admin/admin_activity.php
@@ -168,13 +168,13 @@ if ($action != '')
             $exporter_output .= "    <severity>" . $result->fields['severity'] . "</severity>\n";
             $exporter_output .= "    <access_date>" . $result->fields['access_date'] . "</access_date>\n";
             $exporter_output .= "    <admin_id>" . $result->fields['admin_id'] . "</admin_id>\n";
-            $exporter_output .= "    <admin_name>" . htmlspecialchars($result->fields['admin_name'], ENT_COMPAT, CHARSET, TRUE) . "</admin_name>\n";
+            $exporter_output .= "    <admin_name>" . zen_output_string_protected($result->fields['admin_name']) . "</admin_name>\n";
             $exporter_output .= "    <ip_address>" . $result->fields['ip_address'] . "</ip_address>\n";
             $exporter_output .= "    <page_accessed>" . $result->fields['page_accessed'] . "</page_accessed>\n";
-            $exporter_output .= "    <page_parameters>" . htmlspecialchars($result->fields['page_parameters'], ENT_COMPAT, CHARSET, TRUE) . "</page_parameters>\n";
-            $exporter_output .= "    <flagged>" . htmlspecialchars($result->fields['flagged'], ENT_COMPAT, CHARSET, TRUE) . "</flagged>\n";
-            $exporter_output .= "    <attention>" . htmlspecialchars($result->fields['attention'], ENT_COMPAT, CHARSET, TRUE) . "</attention>\n";
-            $exporter_output .= "    <logmessage>" . htmlspecialchars($result->fields['logmessage'], ENT_COMPAT, CHARSET, TRUE) . "</logmessage>\n";
+            $exporter_output .= "    <page_parameters>" . zen_output_string_protected($result->fields['page_parameters']) . "</page_parameters>\n";
+            $exporter_output .= "    <flagged>" . zen_output_string_protected($result->fields['flagged']) . "</flagged>\n";
+            $exporter_output .= "    <attention>" . zen_output_string_protected($result->fields['attention']) . "</attention>\n";
+            $exporter_output .= "    <logmessage>" . zen_output_string_protected($result->fields['logmessage']) . "</logmessage>\n";
             $exporter_output .= "    <postdata>" . $postoutput . "</postdata>\n";
             $exporter_output .= "  </row>\n";
           } else
@@ -363,7 +363,7 @@ require (DIR_WS_INCLUDES . 'header.php');
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
           </tr>
           <tr>
-            <td class="main"><strong><?php echo TEXT_ACTIVITY_EXPORT_FILENAME; ?></strong><br /><?php echo zen_draw_input_field('filename', htmlspecialchars($file, ENT_COMPAT, CHARSET, TRUE), ' size="60"'); ?></td>
+            <td class="main"><strong><?php echo TEXT_ACTIVITY_EXPORT_FILENAME; ?></strong><br /><?php echo zen_draw_input_field('filename', zen_output_string_protected($file), ' size="60"'); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>

--- a/admin/admin_activity.php
+++ b/admin/admin_activity.php
@@ -181,7 +181,7 @@ if ($action != '')
           { // output non-XML data-format
             $postoutput = print_r(json_decode(@gzinflate($result->fields['gzpost'])), true);
             if ($format == 'HTML') {
-              $postoutput = nl2br(zen_output_string_protected($postoutput));
+              $postoutput = nl2br(htmlspecialchars($postoutput, ENT_COMPAT, CHARSET, FALSE));
             } else {
               $postoutput = nl2br($postoutput);
             }

--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -853,7 +853,7 @@ function popupWindow(url) {
               </tr>
               <tr>
                 <td class="main" align="center"><?php echo '<span class="alert">' . TEXT_INFO_ATTRIBUTES_FEATURE_COPY_TO . '</span>' . '<br />' . zen_draw_products_pull_down('products_update_id', 'size="15"', $products_exclude_array, true, '', true); ?><br />
-                <span class="alert"><?php echo TEXT_INFO_ATTRIBUTES_FEATURE_COPY_TO_MANUAL; ?></span><br /><input type="text" name="products_update_id_manual" value="<?php echo zen_output_string_protected($_POST['products_update_id_manual']); ?>" size="6"><br /><br /></td>
+                <span class="alert"><?php echo TEXT_INFO_ATTRIBUTES_FEATURE_COPY_TO_MANUAL; ?></span><br /><input type="text" name="products_update_id_manual" value="<?php echo htmlspecialchars($_POST['products_update_id_manual'], ENT_COMPAT, CHARSET, FALSE); ?>" size="6"><br /><br /></td>
                 </td>
                 <td class="main" align="center"><?php echo zen_image_submit('button_copy.gif', IMAGE_COPY) . '&nbsp;&nbsp;' . '<a href="' . zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $products_filter . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a>'; ?></td>
               </tr>
@@ -878,7 +878,7 @@ function popupWindow(url) {
               </tr>
               <tr>
                 <td class="main" align="center"><?php echo '<span class="alert">' . TEXT_INFO_ATTRIBUTES_FEATURE_CATEGORIES_COPY_TO . '</span>' . '<br />' . zen_draw_products_pull_down_categories('categories_update_id', 'size="5"', '', true, true); ?><br />
-                <span class="alert"><?php echo TEXT_INFO_ATTRIBUTES_FEATURE_CATEGORIES_COPY_TO_MANUAL; ?></span><br /><input type="text" name="categories_update_id_manual" value="<?php echo zen_output_string_protected($_POST['categories_update_id_manual']); ?>" size="6"><br /><br /></td>
+                <span class="alert"><?php echo TEXT_INFO_ATTRIBUTES_FEATURE_CATEGORIES_COPY_TO_MANUAL; ?></span><br /><input type="text" name="categories_update_id_manual" value="<?php echo htmlspecialchars($_POST['categories_update_id_manual'], ENT_COMPAT, CHARSET, FALSE); ?>" size="6"><br /><br /></td>
                 <td class="main" align="center"><?php echo zen_image_submit('button_copy.gif', IMAGE_COPY) . '&nbsp;&nbsp;' . '<a href="' . zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $products_filter . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a>'; ?></td>
               </tr>
             </table></td>

--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -311,7 +311,7 @@ function popupImageWindow(url) {
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_BANNERS_TITLE; ?></td>
-            <td class="main"><?php echo zen_draw_input_field('banners_title', htmlspecialchars($bInfo->banners_title, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_BANNERS, 'banners_title'), true); ?></td>
+            <td class="main"><?php echo zen_draw_input_field('banners_title', zen_output_string_protected($bInfo->banners_title), zen_set_field_length(TABLE_BANNERS, 'banners_title'), true); ?></td>
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_BANNERS_URL; ?></td>
@@ -343,7 +343,7 @@ function popupImageWindow(url) {
           </tr>
           <tr>
             <td valign="top" class="main"><?php echo TEXT_BANNERS_HTML_TEXT; ?></td>
-            <td class="main"><?php echo TEXT_BANNERS_HTML_TEXT_INFO . '<br />' . zen_draw_textarea_field('banners_html_text', 'soft', '80', '10', htmlspecialchars($bInfo->banners_html_text, ENT_COMPAT, CHARSET, TRUE), 'class="' . (preg_match('/.*?(?:\[CDATA\[|<script)/', $bInfo->banners_html_text) ? 'noEditor' : 'editorHook') . '"'); ?></td>
+            <td class="main"><?php echo TEXT_BANNERS_HTML_TEXT_INFO . '<br />' . zen_draw_textarea_field('banners_html_text', 'soft', '80', '10', zen_output_string_protected($bInfo->banners_html_text), 'class="' . (preg_match('/.*?(?:\[CDATA\[|<script)/', $bInfo->banners_html_text) ? 'noEditor' : 'editorHook') . '"'); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -694,7 +694,7 @@ require('includes/admin_html_head.php');
 
     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
       $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;';
-      $category_inputs_string .= zen_draw_textarea_field('categories_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', htmlspecialchars(zen_get_category_description($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"');
+      $category_inputs_string .= zen_draw_textarea_field('categories_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', zen_output_string_protected(zen_get_category_description($cInfo->categories_id, $languages[$i]['id'])), 'class="editorHook"');
     }
     $contents[] = array('text' => '<br />' . TEXT_CATEGORIES_DESCRIPTION . $category_inputs_string);
     $contents[] = array('text' => '<br />' . TEXT_CATEGORIES_IMAGE . '<br />' . zen_draw_file_field('categories_image'));
@@ -722,13 +722,13 @@ require('includes/admin_html_head.php');
 
     $category_inputs_string = '';
     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
-      $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', htmlspecialchars(zen_get_category_name($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
+      $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(zen_get_category_name($cInfo->categories_id, $languages[$i]['id'])), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
     }
     $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_NAME . $category_inputs_string);
     $category_inputs_string = '';
     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
       $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' ;
-      $category_inputs_string .= zen_draw_textarea_field('categories_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', htmlspecialchars(zen_get_category_description($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"');
+      $category_inputs_string .= zen_draw_textarea_field('categories_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', zen_output_string_protected(zen_get_category_description($cInfo->categories_id, $languages[$i]['id'])), 'class="editorHook"');
     }
     $contents[] = array('text' => '<br />' . TEXT_CATEGORIES_DESCRIPTION . $category_inputs_string);
     $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_IMAGE . '<br />' . zen_draw_file_field('categories_image'));
@@ -792,21 +792,21 @@ require('includes/admin_html_head.php');
 
     $category_inputs_string_metatags_title = '';
     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
-      $category_inputs_string_metatags_title .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['metatags_title']) . '&nbsp;' . zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(zen_get_category_metatags_title($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_METATAGS_CATEGORIES_DESCRIPTION, 'metatags_title'));
+      $category_inputs_string_metatags_title .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['metatags_title']) . '&nbsp;' . zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(zen_get_category_metatags_title($cInfo->categories_id, $languages[$i]['id'])), zen_set_field_length(TABLE_METATAGS_CATEGORIES_DESCRIPTION, 'metatags_title'));
     }
     $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_META_TAGS_TITLE . $category_inputs_string_metatags_title);
 
     $category_inputs_string_metatags_keywords = '';
     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
       $category_inputs_string_metatags_keywords .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['metatags_keywords']) . '&nbsp;' ;
-      $category_inputs_string_metatags_keywords .= zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', htmlspecialchars(zen_get_category_metatags_keywords($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"');
+      $category_inputs_string_metatags_keywords .= zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', zen_output_string_protected(zen_get_category_metatags_keywords($cInfo->categories_id, $languages[$i]['id'])), 'class="noEditor"');
     }
     $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_META_TAGS_KEYWORDS . $category_inputs_string_metatags_keywords);
 
     $category_inputs_string_metatags_description = '';
     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
       $category_inputs_string_metatags_description .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' ;
-      $category_inputs_string_metatags_description .= zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', htmlspecialchars(zen_get_category_metatags_description($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"');
+      $category_inputs_string_metatags_description .= zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '20', zen_output_string_protected(zen_get_category_metatags_description($cInfo->categories_id, $languages[$i]['id'])), 'class="noEditor"');
     }
     $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_META_TAGS_DESCRIPTION . $category_inputs_string_metatags_description);
 

--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -150,7 +150,7 @@ require('includes/admin_html_head.php');
     }
 ?>
                 <td class="dataTableContent"><?php echo $configuration->fields['configuration_title']; ?></td>
-                <td class="dataTableContent"><?php echo htmlspecialchars($cfgValue, ENT_COMPAT, CHARSET, TRUE); ?></td>
+                <td class="dataTableContent"><?php echo zen_output_string_protected($cfgValue); ?></td>
                 <td class="dataTableContent" align="right"><?php if ( (isset($cInfo) && is_object($cInfo)) && ($configuration->fields['configuration_id'] == $cInfo->configuration_id) ) { echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', ''); } else { echo '<a href="' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $configuration->fields['configuration_id']) . '" name="link_' . $configuration->fields['configuration_key'] . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>'; } ?>&nbsp;</td>
               </tr>
 <?php
@@ -175,9 +175,9 @@ require('includes/admin_html_head.php');
       $heading[] = array('text' => '<b>' . $cInfo->configuration_title . '</b>');
 
       if ($cInfo->set_function) {
-        eval('$value_field = ' . $cInfo->set_function . '"' . htmlspecialchars($cInfo->configuration_value, ENT_COMPAT, CHARSET, TRUE) . '");');
+        eval('$value_field = ' . $cInfo->set_function . '"' . zen_output_string_protected($cInfo->configuration_value) . '");');
       } else {
-        $value_field = zen_draw_input_field('configuration_value', htmlspecialchars($cInfo->configuration_value, ENT_COMPAT, CHARSET, TRUE), 'size="60"');
+        $value_field = zen_draw_input_field('configuration_value', zen_output_string_protected($cInfo->configuration_value), 'size="60"');
       }
 
       $contents = array('form' => zen_draw_form('configuration', FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $cInfo->configuration_id . '&action=save'));

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -757,13 +757,13 @@ function check_form(form_name) {
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
               </tr>
               <tr>
-                <td class="smallText"><b><?php echo TEXT_FROM; ?></b><br /><?php echo htmlspecialchars(stripslashes($_POST['from']), ENT_COMPAT, CHARSET, TRUE); ?></td>
+                <td class="smallText"><b><?php echo TEXT_FROM; ?></b><br /><?php echo zen_output_string_protected(stripslashes($_POST['from'])); ?></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
               </tr>
               <tr>
-                <td class="smallText"><b><?php echo TEXT_SUBJECT; ?></b><br /><?php echo htmlspecialchars(stripslashes($_POST['subject']), ENT_COMPAT, CHARSET, TRUE); ?></td>
+                <td class="smallText"><b><?php echo TEXT_SUBJECT; ?></b><br /><?php echo zen_output_string_protected(stripslashes($_POST['subject'])); ?></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -772,7 +772,7 @@ function check_form(form_name) {
                 <td><hr /><b><?php echo TEXT_RICH_TEXT_MESSAGE; ?></b><br /><?php echo stripslashes($_POST['message_html']); ?></td>
               </tr>
               <tr>
-                <td ><hr /><b><?php echo TEXT_MESSAGE; ?></b><br /><tt><?php echo nl2br(htmlspecialchars(stripslashes($_POST['message']), ENT_COMPAT, CHARSET, TRUE)); ?></tt><hr /></td>
+                <td ><hr /><b><?php echo TEXT_MESSAGE; ?></b><br /><tt><?php echo nl2br(zen_output_string_protected(stripslashes($_POST['message']))); ?></tt><hr /></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -784,7 +784,7 @@ function check_form(form_name) {
     reset($_POST);
     while (list($key, $value) = each($_POST)) {
       if (!is_array($_POST[$key])) {
-        echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
       }
     }
 ?>
@@ -869,12 +869,12 @@ function check_form(form_name) {
 <?php   if (EMAIL_USE_HTML == 'true') { ?>
               <tr>
                 <td valign="top" class="main"><?php echo TEXT_RICH_TEXT_MESSAGE; ?></td>
-                <td><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '25', htmlspecialchars(($_POST['message_html']=='') ? TEXT_COUPON_ANNOUNCE : stripslashes($_POST['message_html']), ENT_COMPAT, CHARSET, TRUE), 'id="message_html" class="editorHook"'); ?></td>
+                <td><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '25', zen_output_string_protected(($_POST['message_html']=='') ? TEXT_COUPON_ANNOUNCE : stripslashes($_POST['message_html'])), 'id="message_html" class="editorHook"'); ?></td>
               </tr>
 <?php } ?>
               <tr>
                 <td valign="top" class="main"><?php echo TEXT_MESSAGE; ?>&nbsp;&nbsp;</td>
-                <td><?php echo zen_draw_textarea_field('message', 'soft', '60', '15', htmlspecialchars(strip_tags(($_POST['message_html']=='') ? TEXT_COUPON_ANNOUNCE : stripslashes($_POST['message_html'])), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); ?></td>
+                <td><?php echo zen_draw_textarea_field('message', 'soft', '60', '15', zen_output_string_protected(strip_tags(($_POST['message_html']=='') ? TEXT_COUPON_ANNOUNCE : stripslashes($_POST['message_html']))), 'class="noEditor"'); ?></td>
               </tr>
               <tr>
                 <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -1121,7 +1121,7 @@ function check_form(form_name) {
 ?>
       <tr>
         <td align="left" class="main"><?php if ($i==0) echo COUPON_NAME; ?></td>
-        <td align="left"><?php echo zen_draw_input_field('coupon_name[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($_POST['coupon_name'][$language_id]), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_COUPONS_DESCRIPTION, 'coupon_name')) . '&nbsp;' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?></td>
+        <td align="left"><?php echo zen_draw_input_field('coupon_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($_POST['coupon_name'][$language_id])), zen_set_field_length(TABLE_COUPONS_DESCRIPTION, 'coupon_name')) . '&nbsp;' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?></td>
         <td align="left" class="main" width="40%"><?php if ($i==0) echo COUPON_NAME_HELP; ?></td>
       </tr>
 <?php
@@ -1135,7 +1135,7 @@ function check_form(form_name) {
 
       <tr>
         <td align="left" valign="top" class="main"><?php if ($i==0) echo COUPON_DESC; ?></td>
-        <td align="left" valign="top"><?php echo zen_draw_textarea_field('coupon_desc[' . $languages[$i]['id'] . ']','physical','24','8', htmlspecialchars(stripslashes($_POST['coupon_desc'][$language_id]), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"'); ?>
+        <td align="left" valign="top"><?php echo zen_draw_textarea_field('coupon_desc[' . $languages[$i]['id'] . ']','physical','24','8', zen_output_string_protected(stripslashes($_POST['coupon_desc'][$language_id])), 'class="editorHook"'); ?>
             <?php echo '&nbsp;' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?></td>
         <td align="left" valign="top" class="main"><?php if ($i==0) echo COUPON_DESC_HELP; ?></td>
       </tr>
@@ -1177,7 +1177,7 @@ function check_form(form_name) {
 
       <tr>
         <td align="left" class="main"><?php echo COUPON_CODE; ?></td>
-        <td align="left"><?php echo zen_draw_input_field('coupon_code', htmlspecialchars($_POST['coupon_code'], ENT_COMPAT, CHARSET, TRUE)); ?></td>
+        <td align="left"><?php echo zen_draw_input_field('coupon_code', zen_output_string_protected($_POST['coupon_code'])); ?></td>
         <td align="left" class="main"><?php echo COUPON_CODE_HELP; ?></td>
       </tr>
       <tr>

--- a/admin/coupon_admin_export.php
+++ b/admin/coupon_admin_export.php
@@ -135,7 +135,7 @@ if ($action != '')
             $exporter_output .= "<coupon_export_log>\n";
             $exporter_output .= "  <row>\n";
             $exporter_output .= "    <coupon_id>" . $result->fields['coupon_id'] . "</coupon_id>\n";
-            $exporter_output .= "    <coupon_code>" . htmlspecialchars($result->fields['coupon_code'], ENT_COMPAT, CHARSET, TRUE) . "</coupon_code>\n";
+            $exporter_output .= "    <coupon_code>" . zen_output_string_protected($result->fields['coupon_code']) . "</coupon_code>\n";
             $exporter_output .= "    <coupon_amount>" . $result->fields['coupon_amount'] . "</coupon_amount>\n";
             $exporter_output .= "    <coupon_type>" . $result->fields['coupon_type'] . "</coupon_type>\n";
             $exporter_output .= "    <coupon_minimum_order>" . $result->fields['coupon_minimum_order'] . "</coupon_minimum_order>\n";
@@ -309,7 +309,7 @@ require (DIR_WS_INCLUDES . 'header.php');
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
           </tr>
           <tr>
-            <td class="main"><strong><?php echo TEXT_ACTIVITY_EXPORT_FILENAME; ?></strong><br /><?php echo zen_draw_input_field('filename', htmlspecialchars($file, ENT_COMPAT, CHARSET, TRUE), ' size="60"'); ?></td>
+            <td class="main"><strong><?php echo TEXT_ACTIVITY_EXPORT_FILENAME; ?></strong><br /><?php echo zen_draw_input_field('filename', zen_output_string_protected($file), ' size="60"'); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -56,7 +56,7 @@
  */
   foreach ($addressArray as $address) {
 ?>
-<h3 class="addressBookDefaultName"><?php echo zen_output_string_protected($address['firstname'] . ' ' . $address['lastname']); ?><?php if ($address['address_book_id'] == zen_get_customers_address_primary($_GET['cID'])) echo '&nbsp;' . PRIMARY_ADDRESS ; ?></h3>
+<h3 class="addressBookDefaultName"><?php echo htmlspecialchars($address['firstname'] . ' ' . $address['lastname'], ENT_COMPAT, CHARSET, FALSE); ?><?php if ($address['address_book_id'] == zen_get_customers_address_primary($_GET['cID'])) echo '&nbsp;' . PRIMARY_ADDRESS ; ?></h3>
 <address><?php echo zen_address_format($address['format_id'], $address['address'], true, ' ', '<br />'); ?></address>
 
 <br class="clearBoth" />
@@ -976,7 +976,7 @@ if ($processed == true) {
     echo HEADING_TITLE_SEARCH_DETAIL . ' ' . zen_draw_input_field('search') . zen_hide_session_id();
     if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
       $keywords = zen_db_prepare_input($_GET['search']);
-      echo '<br/ >' . TEXT_INFO_SEARCH_DETAIL_FILTER . zen_output_string_protected($keywords);
+      echo '<br/ >' . TEXT_INFO_SEARCH_DETAIL_FILTER . htmlspecialchars($keywords, ENT_COMPAT, CHARSET, FALSE);
     }
 ?>
             </td>
@@ -1282,7 +1282,7 @@ $().ready(function() {
 </script>');
       break;
     default:
-      if (isset($_GET['search'])) $_GET['search'] = zen_output_string_protected($_GET['search']);
+      if (isset($_GET['search'])) $_GET['search'] = htmlspecialchars($_GET['search'], ENT_COMPAT, CHARSET, FALSE);
       if (isset($cInfo) && is_object($cInfo)) {
         $customers_orders = $db->Execute("select o.orders_id, o.date_purchased, o.order_total, o.currency, o.currency_value,
                                           cgc.amount

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -616,12 +616,12 @@ function check_form() {
 <?php
   if ($error == true) {
     if ($entry_firstname_error == true) {
-      echo zen_draw_input_field('customers_firstname', htmlspecialchars($cInfo->customers_firstname, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_firstname', 50)) . '&nbsp;' . ENTRY_FIRST_NAME_ERROR;
+      echo zen_draw_input_field('customers_firstname', zen_output_string_protected($cInfo->customers_firstname), zen_set_field_length(TABLE_CUSTOMERS, 'customers_firstname', 50)) . '&nbsp;' . ENTRY_FIRST_NAME_ERROR;
     } else {
       echo $cInfo->customers_firstname . zen_draw_hidden_field('customers_firstname');
     }
   } else {
-    echo zen_draw_input_field('customers_firstname', htmlspecialchars($cInfo->customers_firstname, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_firstname', 50), true);
+    echo zen_draw_input_field('customers_firstname', zen_output_string_protected($cInfo->customers_firstname), zen_set_field_length(TABLE_CUSTOMERS, 'customers_firstname', 50), true);
   }
 ?></td>
           </tr>
@@ -631,12 +631,12 @@ function check_form() {
 <?php
   if ($error == true) {
     if ($entry_lastname_error == true) {
-      echo zen_draw_input_field('customers_lastname', htmlspecialchars($cInfo->customers_lastname, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_lastname', 50)) . '&nbsp;' . ENTRY_LAST_NAME_ERROR;
+      echo zen_draw_input_field('customers_lastname', zen_output_string_protected($cInfo->customers_lastname), zen_set_field_length(TABLE_CUSTOMERS, 'customers_lastname', 50)) . '&nbsp;' . ENTRY_LAST_NAME_ERROR;
     } else {
       echo $cInfo->customers_lastname . zen_draw_hidden_field('customers_lastname');
     }
   } else {
-    echo zen_draw_input_field('customers_lastname', htmlspecialchars($cInfo->customers_lastname, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_lastname', 50), true);
+    echo zen_draw_input_field('customers_lastname', zen_output_string_protected($cInfo->customers_lastname), zen_set_field_length(TABLE_CUSTOMERS, 'customers_lastname', 50), true);
   }
 ?></td>
           </tr>
@@ -668,16 +668,16 @@ function check_form() {
 <?php
   if ($error == true) {
     if ($entry_email_address_error == true) {
-      echo zen_draw_input_field('customers_email_address', htmlspecialchars($cInfo->customers_email_address, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50)) . '&nbsp;' . ENTRY_EMAIL_ADDRESS_ERROR;
+      echo zen_draw_input_field('customers_email_address', zen_output_string_protected($cInfo->customers_email_address), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50)) . '&nbsp;' . ENTRY_EMAIL_ADDRESS_ERROR;
     } elseif ($entry_email_address_check_error == true) {
-      echo zen_draw_input_field('customers_email_address', htmlspecialchars($cInfo->customers_email_address, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50)) . '&nbsp;' . ENTRY_EMAIL_ADDRESS_CHECK_ERROR;
+      echo zen_draw_input_field('customers_email_address', zen_output_string_protected($cInfo->customers_email_address), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50)) . '&nbsp;' . ENTRY_EMAIL_ADDRESS_CHECK_ERROR;
     } elseif ($entry_email_address_exists == true) {
-      echo zen_draw_input_field('customers_email_address', htmlspecialchars($cInfo->customers_email_address, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50)) . '&nbsp;' . ENTRY_EMAIL_ADDRESS_ERROR_EXISTS;
+      echo zen_draw_input_field('customers_email_address', zen_output_string_protected($cInfo->customers_email_address), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50)) . '&nbsp;' . ENTRY_EMAIL_ADDRESS_ERROR_EXISTS;
     } else {
       echo $customers_email_address . zen_draw_hidden_field('customers_email_address');
     }
   } else {
-    echo zen_draw_input_field('customers_email_address', htmlspecialchars($cInfo->customers_email_address, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50), true);
+    echo zen_draw_input_field('customers_email_address', zen_output_string_protected($cInfo->customers_email_address), zen_set_field_length(TABLE_CUSTOMERS, 'customers_email_address', 50), true);
   }
 ?></td>
           </tr>
@@ -700,12 +700,12 @@ function check_form() {
 <?php
     if ($error == true) {
       if ($entry_company_error == true) {
-        echo zen_draw_input_field('entry_company', htmlspecialchars($cInfo->entry_company, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_company', 50)) . '&nbsp;' . ENTRY_COMPANY_ERROR;
+        echo zen_draw_input_field('entry_company', zen_output_string_protected($cInfo->entry_company), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_company', 50)) . '&nbsp;' . ENTRY_COMPANY_ERROR;
       } else {
         echo $cInfo->entry_company . zen_draw_hidden_field('entry_company');
       }
     } else {
-      echo zen_draw_input_field('entry_company', htmlspecialchars($cInfo->entry_company, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_company', 50));
+      echo zen_draw_input_field('entry_company', zen_output_string_protected($cInfo->entry_company), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_company', 50));
     }
 ?></td>
           </tr>
@@ -728,12 +728,12 @@ function check_form() {
 <?php
   if ($error == true) {
     if ($entry_street_address_error == true) {
-      echo zen_draw_input_field('entry_street_address', htmlspecialchars($cInfo->entry_street_address, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_street_address', 50)) . '&nbsp;' . ENTRY_STREET_ADDRESS_ERROR;
+      echo zen_draw_input_field('entry_street_address', zen_output_string_protected($cInfo->entry_street_address), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_street_address', 50)) . '&nbsp;' . ENTRY_STREET_ADDRESS_ERROR;
     } else {
       echo $cInfo->entry_street_address . zen_draw_hidden_field('entry_street_address');
     }
   } else {
-    echo zen_draw_input_field('entry_street_address', htmlspecialchars($cInfo->entry_street_address, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_street_address', 50), true);
+    echo zen_draw_input_field('entry_street_address', zen_output_string_protected($cInfo->entry_street_address), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_street_address', 50), true);
   }
 ?></td>
           </tr>
@@ -746,12 +746,12 @@ function check_form() {
 <?php
     if ($error == true) {
       if ($entry_suburb_error == true) {
-        echo zen_draw_input_field('suburb', htmlspecialchars($cInfo->entry_suburb, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_suburb', 50)) . '&nbsp;' . ENTRY_SUBURB_ERROR;
+        echo zen_draw_input_field('suburb', zen_output_string_protected($cInfo->entry_suburb), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_suburb', 50)) . '&nbsp;' . ENTRY_SUBURB_ERROR;
       } else {
         echo $cInfo->entry_suburb . zen_draw_hidden_field('entry_suburb');
       }
     } else {
-      echo zen_draw_input_field('entry_suburb', htmlspecialchars($cInfo->entry_suburb, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_suburb', 50));
+      echo zen_draw_input_field('entry_suburb', zen_output_string_protected($cInfo->entry_suburb), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_suburb', 50));
     }
 ?></td>
           </tr>
@@ -764,12 +764,12 @@ function check_form() {
 <?php
   if ($error == true) {
     if ($entry_post_code_error == true) {
-      echo zen_draw_input_field('entry_postcode', htmlspecialchars($cInfo->entry_postcode, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_postcode', 10)) . '&nbsp;' . ENTRY_POST_CODE_ERROR;
+      echo zen_draw_input_field('entry_postcode', zen_output_string_protected($cInfo->entry_postcode), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_postcode', 10)) . '&nbsp;' . ENTRY_POST_CODE_ERROR;
     } else {
       echo $cInfo->entry_postcode . zen_draw_hidden_field('entry_postcode');
     }
   } else {
-    echo zen_draw_input_field('entry_postcode', htmlspecialchars($cInfo->entry_postcode, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_postcode', 10), true);
+    echo zen_draw_input_field('entry_postcode', zen_output_string_protected($cInfo->entry_postcode), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_postcode', 10), true);
   }
 ?></td>
           </tr>
@@ -779,12 +779,12 @@ function check_form() {
 <?php
   if ($error == true) {
     if ($entry_city_error == true) {
-      echo zen_draw_input_field('entry_city', htmlspecialchars($cInfo->entry_city, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_city', 50)) . '&nbsp;' . ENTRY_CITY_ERROR;
+      echo zen_draw_input_field('entry_city', zen_output_string_protected($cInfo->entry_city), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_city', 50)) . '&nbsp;' . ENTRY_CITY_ERROR;
     } else {
       echo $cInfo->entry_city . zen_draw_hidden_field('entry_city');
     }
   } else {
-    echo zen_draw_input_field('entry_city', htmlspecialchars($cInfo->entry_city, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_city', 50), true);
+    echo zen_draw_input_field('entry_city', zen_output_string_protected($cInfo->entry_city), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_city', 50), true);
   }
 ?></td>
           </tr>
@@ -810,13 +810,13 @@ function check_form() {
           }
           echo zen_draw_pull_down_menu('entry_state', $zones_array) . '&nbsp;' . ENTRY_STATE_ERROR;
         } else {
-          echo zen_draw_input_field('entry_state', htmlspecialchars(zen_get_zone_name($cInfo->entry_country_id, $cInfo->entry_zone_id, $cInfo->entry_state), ENT_COMPAT, CHARSET, TRUE)) . '&nbsp;' . ENTRY_STATE_ERROR;
+          echo zen_draw_input_field('entry_state', zen_output_string_protected(zen_get_zone_name($cInfo->entry_country_id, $cInfo->entry_zone_id, $cInfo->entry_state))) . '&nbsp;' . ENTRY_STATE_ERROR;
         }
       } else {
         echo $entry_state . zen_draw_hidden_field('entry_zone_id') . zen_draw_hidden_field('entry_state');
       }
     } else {
-      echo zen_draw_input_field('entry_state', htmlspecialchars(zen_get_zone_name($cInfo->entry_country_id, $cInfo->entry_zone_id, $cInfo->entry_state), ENT_COMPAT, CHARSET, TRUE));
+      echo zen_draw_input_field('entry_state', zen_output_string_protected(zen_get_zone_name($cInfo->entry_country_id, $cInfo->entry_zone_id, $cInfo->entry_state)));
     }
 
 ?></td>
@@ -855,12 +855,12 @@ function check_form() {
 <?php
   if ($error == true) {
     if ($entry_telephone_error == true) {
-      echo zen_draw_input_field('customers_telephone', htmlspecialchars($cInfo->customers_telephone, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_telephone', 15)) . '&nbsp;' . ENTRY_TELEPHONE_NUMBER_ERROR;
+      echo zen_draw_input_field('customers_telephone', zen_output_string_protected($cInfo->customers_telephone), zen_set_field_length(TABLE_CUSTOMERS, 'customers_telephone', 15)) . '&nbsp;' . ENTRY_TELEPHONE_NUMBER_ERROR;
     } else {
       echo $cInfo->customers_telephone . zen_draw_hidden_field('customers_telephone');
     }
   } else {
-    echo zen_draw_input_field('customers_telephone', htmlspecialchars($cInfo->customers_telephone, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_telephone', 15), true);
+    echo zen_draw_input_field('customers_telephone', zen_output_string_protected($cInfo->customers_telephone), zen_set_field_length(TABLE_CUSTOMERS, 'customers_telephone', 15), true);
   }
 ?></td>
           </tr>
@@ -874,7 +874,7 @@ function check_form() {
   if ($processed == true) {
     echo $cInfo->customers_fax . zen_draw_hidden_field('customers_fax');
   } else {
-    echo zen_draw_input_field('customers_fax', htmlspecialchars($cInfo->customers_fax, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_fax', 15));
+    echo zen_draw_input_field('customers_fax', zen_output_string_protected($cInfo->customers_fax), zen_set_field_length(TABLE_CUSTOMERS, 'customers_fax', 15));
   }
 ?></td>
           </tr>
@@ -947,7 +947,7 @@ if ($processed == true) {
           <tr>
             <td class="main"><?php echo CUSTOMERS_REFERRAL; ?></td>
             <td class="main">
-              <?php echo zen_draw_input_field('customers_referral', htmlspecialchars($cInfo->customers_referral, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMERS, 'customers_referral', 15)); ?>
+              <?php echo zen_draw_input_field('customers_referral', zen_output_string_protected($cInfo->customers_referral), zen_set_field_length(TABLE_CUSTOMERS, 'customers_referral', 15)); ?>
             </td>
           </tr>
         </table></td>

--- a/admin/define_pages_editor.php
+++ b/admin/define_pages_editor.php
@@ -151,7 +151,7 @@ if (isset($_GET['filename'])) {
           <tr><?php echo zen_draw_form('language', FILENAME_DEFINE_PAGES_EDITOR, 'lngdir=' . $_SESSION['language'] . '&filename=' . $_GET['filename'] . '&action=save'); ?>
             <td><table border="0" cellspacing="0" cellpadding="2">
               <tr>
-                <td class="main"><?php echo zen_draw_textarea_field('file_contents', 'soft', '100%', '30', htmlspecialchars($file_contents, ENT_COMPAT, CHARSET, TRUE), (($file_writeable) ? '' : 'readonly') . ' id="file_contents" class="editorHook"'); ?></td>
+                <td class="main"><?php echo zen_draw_textarea_field('file_contents', 'soft', '100%', '30', zen_output_string_protected($file_contents), (($file_writeable) ? '' : 'readonly') . ' id="file_contents" class="editorHook"'); ?></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -184,7 +184,7 @@
           }
 
           // use to debug for UTF-8 NO BOM on files: test search on a, e, s change if below to true
-          if (false && htmlspecialchars($line, ENT_QUOTES, CHARSET) == '') {
+          if (false && htmlspecialchars($line, ENT_QUOTES, CHARSET, TRUE) == '') {
             echo '<br>SOMETHING BROKE in: ' . $file . '<br>on: ' . $line_num . ' - ' . $line . '<br>';
             $search_found = false;
           }
@@ -258,7 +258,7 @@
       $input = preg_replace('#(' . $highlight . ')#' . (!$case_sensitive ? 'i' : ''), '~~!~~!~~\1~!!~!!~', $input);
     }
     // sanitize output
-    $input = htmlspecialchars($input, ENT_QUOTES, CHARSET);
+    $input = htmlspecialchars($input, ENT_QUOTES, CHARSET, TRUE);
 
     // keep original "spaces" (doesn't account for tabs)
     $input = str_replace(' ', '&nbsp;', $input);

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -123,7 +123,7 @@
         $check_configure = $db->Execute($sql);
       }
       if ($check_configure->RecordCount() >= 1) {
-        $links = '<strong><span class="alert">' . TEXT_SEARCH_DATABASE_TABLES . '</span></strong> ' . '<a href="' . zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=' . 'locate_configuration' . '&configuration_key_lookup=' . zen_output_string_protected($configuration_key_lookup)) . '">' . zen_output_string_protected($configuration_key_lookup) . '</a><br /><br />';
+        $links = '<strong><span class="alert">' . TEXT_SEARCH_DATABASE_TABLES . '</span></strong> ' . '<a href="' . zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=' . 'locate_configuration' . '&configuration_key_lookup=' . htmlspecialchars($configuration_key_lookup, ENT_COMPAT, CHARSET, FALSE)) . '">' . htmlspecialchars($configuration_key_lookup, ENT_COMPAT, CHARSET, FALSE) . '</a><br /><br />';
       } else {
         // do nothing
       }
@@ -136,7 +136,7 @@
       // only ask if found
       echo '<tr><td>' . $links . '</td></tr>';
     }
-    echo '<tr class="infoBoxContent"><td class="dataTableHeadingContent">' . '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' . TEXT_INFO_SEARCHING . sizeof($directory_array) . TEXT_INFO_FILES_FOR . zen_output_string_protected($configuration_key_lookup) . '</td></tr></table>' . "\n\n";
+    echo '<tr class="infoBoxContent"><td class="dataTableHeadingContent">' . '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' . TEXT_INFO_SEARCHING . sizeof($directory_array) . TEXT_INFO_FILES_FOR . htmlspecialchars($configuration_key_lookup, ENT_COMPAT, CHARSET, FALSE) . '</td></tr></table>' . "\n\n";
     echo '<tr><td>&nbsp;</td></tr>';
 
 // check all files located
@@ -234,7 +234,7 @@
         echo $show_file . '<table><tr><td>&nbsp;</td></tr></table>';
       } // show file
     }
-    echo '<table border="0" width="100%" cellspacing="2" cellpadding="1" align="center"><tr class="infoBoxContent"><td class="dataTableHeadingContent">' . TEXT_INFO_MATCHES_FOUND . $cnt_found . ' --- ' . TEXT_INFO_SEARCHING . sizeof($directory_array) . TEXT_INFO_FILES_FOR . zen_output_string_protected($configuration_key_lookup) . '</td></tr></table>';
+    echo '<table border="0" width="100%" cellspacing="2" cellpadding="1" align="center"><tr class="infoBoxContent"><td class="dataTableHeadingContent">' . TEXT_INFO_MATCHES_FOUND . $cnt_found . ' --- ' . TEXT_INFO_SEARCHING . sizeof($directory_array) . TEXT_INFO_FILES_FOR . htmlspecialchars($configuration_key_lookup, ENT_COMPAT, CHARSET, FALSE) . '</td></tr></table>';
 
   } // zen_display_files
 
@@ -638,7 +638,7 @@
 
     // if no matches in either databases or selected language directory give an error
     if ($found == false) {
-      $messageStack->add(ERROR_CONFIGURATION_KEY_NOT_FOUND . ' ' . zen_output_string_protected($configuration_key_lookup), 'caution');
+      $messageStack->add(ERROR_CONFIGURATION_KEY_NOT_FOUND . ' ' . htmlspecialchars($configuration_key_lookup, ENT_COMPAT, CHARSET, FALSE), 'caution');
     } elseif (substr($action, 0, 7) == 'locate_') {
       echo '<table width="90%" align="center"><tr><td>' . zen_draw_separator('pixel_black.gif', '100%', '2') . '</td></tr><tr><td>&nbsp;</td></tr></table>' . "\n";
     }
@@ -745,7 +745,7 @@ if (isset($show_configuration_info) && $show_configuration_info == true) {
           <tr class="infoBoxContent">
             <td colspan="2" class="pageHeading" align="center">
 <?php
-      $links = '<br /><strong><span class="alert">' . TEXT_SEARCH_ALL_FILES . '</span></strong> ' . '<a href="' . zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=' . 'locate_all_files' . '&configuration_key_lookup=' . zen_output_string_protected($configuration_key_lookup) . '&zv_files=1') . '">' . zen_output_string_protected($configuration_key_lookup) . '</a><br />';
+      $links = '<br /><strong><span class="alert">' . TEXT_SEARCH_ALL_FILES . '</span></strong> ' . '<a href="' . zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=' . 'locate_all_files' . '&configuration_key_lookup=' . htmlspecialchars($configuration_key_lookup, ENT_COMPAT, CHARSET, FALSE) . '&zv_files=1') . '">' . htmlspecialchars($configuration_key_lookup, ENT_COMPAT, CHARSET, FALSE) . '</a><br />';
       echo $links;
 ?>
             </td>
@@ -812,7 +812,7 @@ if (false) {
             <td class="main" align="left" valign="middle"><?php echo SEARCH_CFG_KEYS_HEADING_TITLE; ?></td>
           </tr>
           <tr><form name="search_keys" action="<?php echo zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=search_config_keys' . $flags); ?>" method="post"><?php echo zen_draw_hidden_field('securityToken', $_SESSION['securityToken']); ?>
-            <td class="main" align="left" valign="bottom"><?php echo SEARCH_CFG_KEYS_SEARCH_BOX_TEXT . '<br />' . zen_draw_input_field('search', zen_output_string_protected($search), ' size="40" placeholder="' . SEARCH_CFG_KEYS_FORM_PLACEHOLDER . '"');?>
+            <td class="main" align="left" valign="bottom"><?php echo SEARCH_CFG_KEYS_SEARCH_BOX_TEXT . '<br />' . zen_draw_input_field('search', htmlspecialchars($search, ENT_COMPAT, CHARSET, FALSE), ' size="40" placeholder="' . SEARCH_CFG_KEYS_FORM_PLACEHOLDER . '"');?>
             <input type="submit" value="<?php echo SEARCH_CFG_KEYS_FORM_BUTTON_SEARCH_SORTED_BY_GROUP;?>" title="<?php echo SEARCH_CFG_KEYS_FORM_BUTTON_SEARCH_SORTED_BY_GROUP;?>">
             <input type="button" value="<?php echo SEARCH_CFG_KEYS_FORM_BUTTON_SEARCH_SORTED_BY_KEY;?>" onClick="document.search_keys.action='<?php echo zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=search_config_keys&s=k' . $flags) ?>';document.search_keys.submit();" title="<?php echo SEARCH_CFG_KEYS_FORM_BUTTON_SEARCH_SORTED_BY_KEY;?>">
             <input type="button" value="<?php echo SEARCH_CFG_KEYS_FORM_BUTTON_VIEW_ALL;?>" onClick="document.search_keys.action='<?php echo zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=search_config_keys&t=all' . $flags) ?>';document.search_keys.submit();" title="<?php echo SEARCH_CFG_KEYS_FORM_BUTTON_VIEW_ALL;?>">

--- a/admin/document_general.php
+++ b/admin/document_general.php
@@ -154,7 +154,7 @@ require('includes/admin_html_head.php');
         $category_inputs_string = '';
         $languages = zen_get_languages();
         for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
-          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', htmlspecialchars(zen_get_category_name($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
+          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(zen_get_category_name($cInfo->categories_id, $languages[$i]['id'])), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
         }
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_NAME . $category_inputs_string);
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_IMAGE . '<br />' . zen_draw_file_field('categories_image'));

--- a/admin/document_product.php
+++ b/admin/document_product.php
@@ -154,7 +154,7 @@ require('includes/admin_html_head.php');
         $category_inputs_string = '';
         $languages = zen_get_languages();
         for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
-          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', htmlspecialchars(zen_get_category_name($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
+          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(zen_get_category_name($cInfo->categories_id, $languages[$i]['id'])), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
         }
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_NAME . $category_inputs_string);
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_IMAGE . '<br />' . zen_draw_file_field('categories_image'));

--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -314,7 +314,7 @@ require('includes/admin_html_head.php');
         <td><table border="0" cellspacing="0" cellpadding="2">
           <tr>
             <td class="main"><?php echo TEXT_PAGES_TITLE; ?></td>
-            <td class="main"><?php echo zen_draw_input_field('pages_title', htmlspecialchars($ezInfo->pages_title, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_EZPAGES, 'pages_title'), true); ?></td>
+            <td class="main"><?php echo zen_draw_input_field('pages_title', zen_output_string_protected($ezInfo->pages_title), zen_set_field_length(TABLE_EZPAGES, 'pages_title'), true); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -401,7 +401,7 @@ require('includes/admin_html_head.php');
           </tr>
           <tr>
             <td valign="top" class="main"><?php echo TEXT_PAGES_HTML_TEXT; ?></td>
-            <td class="main"><?php echo zen_draw_textarea_field('pages_html_text', 'soft', '100%', '40', htmlspecialchars($ezInfo->pages_html_text, ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"');?></td>
+            <td class="main"><?php echo zen_draw_textarea_field('pages_html_text', 'soft', '100%', '40', zen_output_string_protected($ezInfo->pages_html_text), 'class="editorHook"');?></td>
           </tr>
 
           <tr>

--- a/admin/group_pricing.php
+++ b/admin/group_pricing.php
@@ -184,7 +184,7 @@ if (($_GET['page'] == '' or $_GET['page'] == '1') and $_GET['gID'] != '') {
 
       $contents = array('form' => zen_draw_form('group_pricing', FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $gInfo->group_id . '&action=save', 'post'));
       $contents[] = array('text' => TEXT_EDIT_INTRO);
-      $contents[] = array('text' => '<br />' . TEXT_GROUP_PRICING_NAME . '<br>' . zen_draw_input_field('group_name', htmlspecialchars($gInfo->group_name, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_GROUP_PRICING, 'group_name')));
+      $contents[] = array('text' => '<br />' . TEXT_GROUP_PRICING_NAME . '<br>' . zen_draw_input_field('group_name', zen_output_string_protected($gInfo->group_name), zen_set_field_length(TABLE_GROUP_PRICING, 'group_name')));
       $contents[] = array('text' => '<br>' . TEXT_GROUP_PRICING_AMOUNT . '<br>' . zen_draw_input_field('group_percentage', $gInfo->group_percentage));
       $contents[] = array('align' => 'center', 'text' => '<br>' . zen_image_submit('button_save.gif', IMAGE_SAVE) . ' <a href="' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $gInfo->group_id) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a>');
       break;

--- a/admin/gv_mail.php
+++ b/admin/gv_mail.php
@@ -282,19 +282,19 @@ function check_form(form_name) {
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
               </tr>
               <tr>
-                <td class="smallText"><b><?php echo TEXT_FROM; ?></b><br /><?php echo htmlspecialchars(stripslashes($_POST['from']), ENT_COMPAT, CHARSET, TRUE); ?></td>
+                <td class="smallText"><b><?php echo TEXT_FROM; ?></b><br /><?php echo zen_output_string_protected(stripslashes($_POST['from'])); ?></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
               </tr>
               <tr>
-                <td class="smallText"><b><?php echo TEXT_SUBJECT; ?></b><br /><?php echo htmlspecialchars(stripslashes($_POST['subject']), ENT_COMPAT, CHARSET, TRUE); ?></td>
+                <td class="smallText"><b><?php echo TEXT_SUBJECT; ?></b><br /><?php echo zen_output_string_protected(stripslashes($_POST['subject'])); ?></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
               </tr>
               <tr>
-                <td class="smallText"><b><?php echo TEXT_AMOUNT; ?></b><br /><?php echo nl2br(htmlspecialchars(stripslashes($_POST['amount']), ENT_COMPAT, CHARSET, TRUE)) . ($_POST['amount'] <= 0 ? '&nbsp;<span class="alert">' . ERROR_GV_AMOUNT . '</span>' : ''); ?></td>
+                <td class="smallText"><b><?php echo TEXT_AMOUNT; ?></b><br /><?php echo nl2br(zen_output_string_protected(stripslashes($_POST['amount']))) . ($_POST['amount'] <= 0 ? '&nbsp;<span class="alert">' . ERROR_GV_AMOUNT . '</span>' : ''); ?></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -303,7 +303,7 @@ function check_form(form_name) {
                 <td><hr /><b><?php echo TEXT_RICH_TEXT_MESSAGE; ?></b><br /><?php echo stripslashes($_POST['message_html']); ?></td>
               </tr>
               <tr>
-                <td><hr /><b><?php echo TEXT_MESSAGE; ?></b><br /><tt><?php echo nl2br(htmlspecialchars(stripslashes($_POST['message']), ENT_COMPAT, CHARSET, TRUE)); ?></tt><hr /></td>
+                <td><hr /><b><?php echo TEXT_MESSAGE; ?></b><br /><tt><?php echo nl2br(zen_output_string_protected(stripslashes($_POST['message']))); ?></tt><hr /></td>
               </tr>
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -315,7 +315,7 @@ function check_form(form_name) {
     reset($_POST);
     while (list($key, $value) = each($_POST)) {
       if (!is_array($_POST[$key])) {
-        echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
       }
     }
 ?>
@@ -355,7 +355,7 @@ function check_form(form_name) {
               </tr>
              <tr>
                 <td class="main"><?php echo TEXT_FROM; ?></td>
-                <td><?php echo zen_draw_input_field('from', htmlspecialchars(EMAIL_FROM, ENT_COMPAT, CHARSET, TRUE), 'size="50"'); ?></td>
+                <td><?php echo zen_draw_input_field('from', zen_output_string_protected(EMAIL_FROM), 'size="50"'); ?></td>
               </tr>
               <tr>
                 <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -377,12 +377,12 @@ function check_form(form_name) {
 <?php if (EMAIL_USE_HTML == 'true') {?>
               <tr>
                 <td valign="top" class="main"><?php echo TEXT_RICH_TEXT_MESSAGE; ?></td>
-                <td><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '20', htmlspecialchars(($_POST['message_html']=='') ? TEXT_GV_ANNOUNCE : stripslashes($_POST['message_html']), ENT_COMPAT, CHARSET, TRUE), 'id="message_html" class="editorHook"'); ?></td>
+                <td><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '20', zen_output_string_protected(($_POST['message_html']=='') ? TEXT_GV_ANNOUNCE : stripslashes($_POST['message_html'])), 'id="message_html" class="editorHook"'); ?></td>
               </tr>
 <?php } ?>
               <tr>
                 <td valign="top" class="main"><?php echo TEXT_MESSAGE; ?></td>
-                <td><?php echo zen_draw_textarea_field('message', 'soft', '60', '15', htmlspecialchars(($_POST['message']=='') ? strip_tags(TEXT_GV_ANNOUNCE) : stripslashes($_POST['message']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); ?></td>
+                <td><?php echo zen_draw_textarea_field('message', 'soft', '60', '15', zen_output_string_protected(($_POST['message']=='') ? strip_tags(TEXT_GV_ANNOUNCE) : stripslashes($_POST['message'])), 'class="noEditor"'); ?></td>
               </tr>
               <tr>
                 <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>

--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -181,7 +181,7 @@ class zcObserverLogEventListener extends base {
   {
     $matches = '';
     if (preg_match_all('~(file://|<iframe|<frame|<embed|<script|<meta)~i', $string, $matches)) {
-      return htmlspecialchars(WARNING_REVIEW_ROGUE_ACTIVITY . ' [' . implode(' and ', $matches[1]) . ']', ENT_COMPAT, CHARSET, true);
+      return htmlspecialchars(WARNING_REVIEW_ROGUE_ACTIVITY . ' [' . implode(' and ', $matches[1]) . ']', ENT_COMPAT, CHARSET, TRUE);
     } else {
       return false;
     }

--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -181,7 +181,7 @@ class zcObserverLogEventListener extends base {
   {
     $matches = '';
     if (preg_match_all('~(file://|<iframe|<frame|<embed|<script|<meta)~i', $string, $matches)) {
-      return htmlspecialchars(WARNING_REVIEW_ROGUE_ACTIVITY . ' [' . implode(' and ', $matches[1]) . ']', ENT_COMPAT, CHARSET, TRUE);
+      return zen_output_string_protected(WARNING_REVIEW_ROGUE_ACTIVITY . ' [' . implode(' and ', $matches[1]) . ']');
     } else {
       return false;
     }

--- a/admin/includes/functions/database.php
+++ b/admin/includes/functions/database.php
@@ -58,9 +58,8 @@
     return $db->insert_ID();
   }
 
-  function zen_db_output($string) {
-    return htmlspecialchars($string, ENT_COMPAT, CHARSET, TRUE);
-  }
+/* function zen_db_output has been deprecated in place of zen_output_string_protected and can be found in the store's
+includes/functions/compatibility.php file */
 
   function zen_db_input($string) {
     global $db;

--- a/admin/includes/functions/functions_customers.php
+++ b/admin/includes/functions/functions_customers.php
@@ -39,21 +39,21 @@
                              where address_format_id = '" . (int)$address_format_id . "'";
 
     $address_format = $db->Execute($address_format_query);
-    $company = zen_output_string_protected($address['company']);
+    $company = htmlspecialchars($address['company'], ENT_COMPAT, CHARSET, FALSE);
     if (isset($address['firstname']) && zen_not_null($address['firstname'])) {
-      $firstname = zen_output_string_protected($address['firstname']);
-      $lastname = zen_output_string_protected($address['lastname']);
+      $firstname = htmlspecialchars($address['firstname'], ENT_COMPAT, CHARSET, FALSE);
+      $lastname = htmlspecialchars($address['lastname'], ENT_COMPAT, CHARSET, FALSE);
     } elseif (isset($address['name']) && zen_not_null($address['name'])) {
-      $firstname = zen_output_string_protected($address['name']);
+      $firstname = htmlspecialchars($address['name'], ENT_COMPAT, CHARSET, FALSE);
       $lastname = '';
     } else {
       $firstname = '';
       $lastname = '';
     }
-    $street = zen_output_string_protected($address['street_address']);
-    $suburb = zen_output_string_protected($address['suburb']);
-    $city = zen_output_string_protected($address['city']);
-    $state = zen_output_string_protected($address['state']);
+    $street = htmlspecialchars($address['street_address'], ENT_COMPAT, CHARSET, FALSE);
+    $suburb = htmlspecialchars($address['suburb'], ENT_COMPAT, CHARSET, FALSE);
+    $city = htmlspecialchars($address['city'], ENT_COMPAT, CHARSET, FALSE);
+    $state = htmlspecialchars($address['state'], ENT_COMPAT, CHARSET, FALSE);
     if (isset($address['country_id']) && zen_not_null($address['country_id'])) {
       $country = zen_get_country_name($address['country_id']);
 
@@ -62,14 +62,14 @@
       }
     } elseif (isset($address['country']) && zen_not_null($address['country'])) {
       if (is_array($address['country'])) {
-        $country = zen_output_string_protected($address['country']['countries_name']);
+        $country = htmlspecialchars($address['country']['countries_name'], ENT_COMPAT, CHARSET, FALSE);
       } else {
-      $country = zen_output_string_protected($address['country']);
+      $country = htmlspecialchars($address['country'], ENT_COMPAT, CHARSET, FALSE);
       }
     } else {
       $country = '';
     }
-    $postcode = zen_output_string_protected($address['postcode']);
+    $postcode = htmlspecialchars($address['postcode'], ENT_COMPAT, CHARSET, FALSE);
     $zip = $postcode;
 
     if ($html) {
@@ -97,9 +97,9 @@
     if ($suburb != '') $streets = $street . $cr . $suburb;
     if ($country == '') {
       if (is_array($address['country'])) {
-        $country = zen_output_string_protected($address['country']['countries_name']);
+        $country = htmlspecialchars($address['country']['countries_name'], ENT_COMPAT, CHARSET, FALSE);
       } else {
-      $country = zen_output_string_protected($address['country']);
+      $country = htmlspecialchars($address['country'], ENT_COMPAT, CHARSET, FALSE);
       }
     }
     if ($state != '') $statecomma = $state . ', ';

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -36,7 +36,7 @@
 
   function zen_output_string($string, $translate = false, $protected = false) {
     if ($protected == true) {
-      return htmlspecialchars($string, ENT_COMPAT, CHARSET, FALSE);
+      return htmlspecialchars($string, ENT_COMPAT, CHARSET, TRUE);
     } else {
       if ($translate == false) {
         return zen_parse_input_field_data($string, array('"' => '&quot;'));

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -126,12 +126,12 @@
           if (!is_array($value)) {
 //             if (is_numeric($value) || (is_string($value) && strlen($value) > 0)) {
             if (strlen($value) > 0) {
-              $get_url .= zen_output_string_protected($key) . '=' . rawurlencode(stripslashes($value)) . '&';
+              $get_url .= htmlspecialchars($key, ENT_COMPAT, CHARSET, FALSE) . '=' . rawurlencode(stripslashes($value)) . '&';
             }
           } else {
             continue; // legacy code doesn't support passing arrays by GET, so skipping any arrays
             foreach(array_filter($value) as $arr){
-              $get_url .= zen_output_string_protected($key) . '[]=' . rawurlencode(stripslashes($arr)) . '&';
+              $get_url .= htmlspecialchars($key, ENT_COMPAT, CHARSET, FALSE) . '[]=' . rawurlencode(stripslashes($arr)) . '&';
             }
           }
         }
@@ -518,21 +518,21 @@
                              from " . TABLE_ADDRESS_FORMAT . "
                              where address_format_id = '" . (int)$address_format_id . "'");
 
-    $company = zen_output_string_protected($address['company']);
+    $company = htmlspecialchars($address['company'], ENT_COMPAT, CHARSET, FALSE);
     if (isset($address['firstname']) && zen_not_null($address['firstname'])) {
-      $firstname = zen_output_string_protected($address['firstname']);
-      $lastname = zen_output_string_protected($address['lastname']);
+      $firstname = htmlspecialchars($address['firstname'], ENT_COMPAT, CHARSET, FALSE);
+      $lastname = htmlspecialchars($address['lastname'], ENT_COMPAT, CHARSET, FALSE);
     } elseif (isset($address['name']) && zen_not_null($address['name'])) {
-      $firstname = zen_output_string_protected($address['name']);
+      $firstname = htmlspecialchars($address['name'], ENT_COMPAT, CHARSET, FALSE);
       $lastname = '';
     } else {
       $firstname = '';
       $lastname = '';
     }
-    $street = zen_output_string_protected($address['street_address']);
-    $suburb = zen_output_string_protected($address['suburb']);
-    $city = zen_output_string_protected($address['city']);
-    $state = zen_output_string_protected($address['state']);
+    $street = htmlspecialchars($address['street_address'], ENT_COMPAT, CHARSET, FALSE);
+    $suburb = htmlspecialchars($address['suburb'], ENT_COMPAT, CHARSET, FALSE);
+    $city = htmlspecialchars($address['city'], ENT_COMPAT, CHARSET, FALSE);
+    $state = htmlspecialchars($address['state'], ENT_COMPAT, CHARSET, FALSE);
     if (isset($address['country_id']) && zen_not_null($address['country_id'])) {
       $country = zen_get_country_name($address['country_id']);
 
@@ -540,11 +540,11 @@
         $state = zen_get_zone_code($address['country_id'], $address['zone_id'], $state);
       }
     } elseif (isset($address['country']) && zen_not_null($address['country'])) {
-      $country = zen_output_string_protected($address['country']);
+      $country = htmlspecialchars($address['country'], ENT_COMPAT, CHARSET, FALSE);
     } else {
       $country = '';
     }
-    $postcode = zen_output_string_protected($address['postcode']);
+    $postcode = htmlspecialchars($address['postcode'], ENT_COMPAT, CHARSET, FALSE);
     $zip = $postcode;
 
     if ($html) {
@@ -570,7 +570,7 @@
     $statecomma = '';
     $streets = $street;
     if ($suburb != '') $streets = $street . $cr . $suburb;
-    if ($country == '') $country = zen_output_string_protected($address['country']);
+    if ($country == '') $country = htmlspecialchars($address['country'], ENT_COMPAT, CHARSET, FALSE);
     if ($state != '') $statecomma = $state . ', ';
 
     $fmt = $address_format->fields['format'];

--- a/admin/includes/functions/logging.php
+++ b/admin/includes/functions/logging.php
@@ -75,7 +75,7 @@ function zen_parse_for_rogue_post($string)
 {
   $matches = '';
   if (preg_match_all('~(file://|<iframe|<frame|<embed|<script|<meta)~i', $string, $matches)) {
-    return htmlspecialchars(WARNING_REVIEW_ROGUE_ACTIVITY . "\n" . implode(' and ', $matches[1]), ENT_COMPAT, CHARSET, TRUE);
+    return zen_output_string_protected(WARNING_REVIEW_ROGUE_ACTIVITY . "\n" . implode(' and ', $matches[1]));
   } else {
     return FALSE;
   }

--- a/admin/includes/modules/category_product_listing.php
+++ b/admin/includes/modules/category_product_listing.php
@@ -35,7 +35,7 @@ if (!isset($_SESSION['display_categories_dropdown'])) {
     echo HEADING_TITLE_SEARCH_DETAIL . ' ' . zen_draw_input_field('search', '', ($action == '' ? 'autofocus="autofocus"' : '')) . zen_hide_session_id();
     if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
       $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-      echo '<br />' . TEXT_INFO_SEARCH_DETAIL_FILTER . zen_output_string_protected($_GET['search']);
+      echo '<br />' . TEXT_INFO_SEARCH_DETAIL_FILTER . htmlspecialchars($_GET['search'], ENT_COMPAT, CHARSET, FALSE);
     }
     echo '</form>';
 ?>

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -263,7 +263,7 @@ echo zen_draw_hidden_field('products_quantity_order_units', 1);
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_DOCUMENT_NAME; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
           </tr>
 <?php
     }
@@ -282,7 +282,7 @@ echo zen_draw_hidden_field('products_quantity_order_units', 1);
             <td colspan="2"><table border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td class="main" width="25" valign="top"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>&nbsp;</td>
-                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', htmlspecialchars((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
+                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', zen_output_string_protected((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id'])), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
               </tr>
             </table></td>
           </tr>
@@ -329,7 +329,7 @@ echo zen_draw_hidden_field('products_quantity_order_units', 1);
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_DOCUMENT_URL . '<br /><small>' . TEXT_DOCUMENT_URL_WITHOUT_HTTP . '</small>'; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
           </tr>
 <?php
     }

--- a/admin/includes/modules/document_general/collect_info_metatags.php
+++ b/admin/includes/modules/document_general/collect_info_metatags.php
@@ -158,19 +158,19 @@ echo zen_draw_form('new_product_meta_tags', $type_admin_handler , 'cPath=' . $cP
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
+              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
         </table></td>

--- a/admin/includes/modules/document_general/preview_info.php
+++ b/admin/includes/modules/document_general/preview_info.php
@@ -136,15 +136,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_name[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_url[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_name[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_description[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_url[$languages[$i]['id']])));
       }
       echo zen_draw_hidden_field('products_image', stripslashes($products_image_name));
       echo ( (isset($_GET['search']) && !empty($_GET['search'])) ? zen_draw_hidden_field('search', $_GET['search']) : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? zen_draw_hidden_field('search', $_POST['search']) : '');

--- a/admin/includes/modules/document_general/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_general/preview_info_meta_tags.php
@@ -110,15 +110,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_title[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_keywords[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_title[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_keywords[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_description[$languages[$i]['id']])));
       }
 
       echo zen_image_submit('button_back.gif', IMAGE_BACK, 'name="edit"') . '&nbsp;&nbsp;';

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -303,7 +303,7 @@ echo zen_draw_hidden_field('products_price_sorter', $pInfo->products_price_sorte
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_PRODUCTS_NAME; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
           </tr>
 <?php
     }
@@ -405,7 +405,7 @@ updateGross();
             <td colspan="2"><table border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td class="main" width="25" valign="top"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>&nbsp;</td>
-                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', htmlspecialchars((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
+                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', zen_output_string_protected((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id'])), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
               </tr>
             </table></td>
           </tr>
@@ -424,7 +424,7 @@ updateGross();
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_PRODUCTS_MODEL; ?></td>
-            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', htmlspecialchars(stripslashes($pInfo->products_model), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
+            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', zen_output_string_protected(stripslashes($pInfo->products_model)), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -467,7 +467,7 @@ updateGross();
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_PRODUCTS_URL . '<br /><small>' . TEXT_PRODUCTS_URL_WITHOUT_HTTP . '</small>'; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
           </tr>
 <?php
     }

--- a/admin/includes/modules/document_product/collect_info_metatags.php
+++ b/admin/includes/modules/document_product/collect_info_metatags.php
@@ -150,19 +150,19 @@ echo zen_draw_form('new_product_meta_tags', $type_admin_handler , 'cPath=' . $cP
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
+              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
         </table></td>

--- a/admin/includes/modules/document_product/preview_info.php
+++ b/admin/includes/modules/document_product/preview_info.php
@@ -143,15 +143,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_name[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_url[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_name[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_description[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_url[$languages[$i]['id']])));
       }
       echo zen_draw_hidden_field('products_image', stripslashes($products_image_name));
       echo ( (isset($_GET['search']) && !empty($_GET['search'])) ? zen_draw_hidden_field('search', $_GET['search']) : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? zen_draw_hidden_field('search', $_POST['search']) : '');

--- a/admin/includes/modules/document_product/preview_info.php
+++ b/admin/includes/modules/document_product/preview_info.php
@@ -55,7 +55,7 @@ if (!defined('IS_ADMIN_FLAG')) {
       <tr>
         <td><table border="0" width="100%" cellspacing="0" cellpadding="0">
           <tr>
-            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_output_string_protected($pInfo->products_name); ?></td>
+            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . htmlspecialchars($pInfo->products_name, ENT_COMPAT, CHARSET, FALSE); ?></td>
             <td class="pageHeading" align="right"><?php echo $currencies->format($pInfo->products_price) . ($pInfo->products_virtual == 1 ? '<span class="errorText">' . '<br />' . TEXT_VIRTUAL_PREVIEW . '</span>' : '') . ($pInfo->product_is_always_free_shipping == 1 ? '<span class="errorText">' . '<br />' . TEXT_FREE_SHIPPING_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_PRICED_BY_ATTRIBUTES_PREVIEW . '</span>' : '') . ($pInfo->product_is_free == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_FREE_PREVIEW . '</span>' : '') . ($pInfo->product_is_call == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_CALL_PREVIEW . '</span>' : '') . ($pInfo->products_qty_box_status == 0 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_QTY_BOX_STATUS_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<br />' . zen_get_products_display_price($_GET['pID']) : ''); ?></td>
           </tr>
         </table></td>

--- a/admin/includes/modules/document_product/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_product/preview_info_meta_tags.php
@@ -107,15 +107,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_title[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_keywords[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_title[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_keywords[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_description[$languages[$i]['id']])));
       }
 
       echo zen_image_submit('button_back.gif', IMAGE_BACK, 'name="edit"') . '&nbsp;&nbsp;';

--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -303,7 +303,7 @@ echo zen_draw_hidden_field('products_price_sorter', $pInfo->products_price_sorte
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_PRODUCTS_NAME; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
           </tr>
 <?php
     }
@@ -405,7 +405,7 @@ updateGross();
             <td colspan="2"><table border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td class="main" width="25" valign="top"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>&nbsp;</td>
-                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', htmlspecialchars((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
+                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', zen_output_string_protected((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id'])), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
               </tr>
             </table></td>
           </tr>
@@ -424,7 +424,7 @@ updateGross();
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_PRODUCTS_MODEL; ?></td>
-            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', htmlspecialchars(stripslashes($pInfo->products_model), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
+            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', zen_output_string_protected(stripslashes($pInfo->products_model)), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -467,7 +467,7 @@ updateGross();
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_PRODUCTS_URL . '<br /><small>' . TEXT_PRODUCTS_URL_WITHOUT_HTTP . '</small>'; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
           </tr>
 <?php
     }

--- a/admin/includes/modules/product/collect_info_metatags.php
+++ b/admin/includes/modules/product/collect_info_metatags.php
@@ -150,19 +150,19 @@ echo zen_draw_form('new_product_meta_tags', $type_admin_handler , 'cPath=' . $cP
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
+              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
         </table></td>

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -53,7 +53,7 @@ if (!defined('IS_ADMIN_FLAG')) {
       <tr>
         <td><table border="0" width="100%" cellspacing="0" cellpadding="0">
           <tr>
-            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_output_string_protected($pInfo->products_name); ?></td>
+            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . htmlspecialchars($pInfo->products_name, ENT_COMPAT, CHARSET, FALSE); ?></td>
             <td class="pageHeading" align="right"><?php echo $currencies->format($pInfo->products_price) . ($pInfo->products_virtual == 1 ? '<span class="errorText">' . '<br />' . TEXT_VIRTUAL_PREVIEW . '</span>' : '') . ($pInfo->product_is_always_free_shipping == 1 ? '<span class="errorText">' . '<br />' . TEXT_FREE_SHIPPING_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_PRICED_BY_ATTRIBUTES_PREVIEW . '</span>' : '') . ($pInfo->product_is_free == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_FREE_PREVIEW . '</span>' : '') . ($pInfo->product_is_call == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_CALL_PREVIEW . '</span>' : '') . ($pInfo->products_qty_box_status == 0 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_QTY_BOX_STATUS_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<br />' . zen_get_products_display_price($_GET['pID']) : ''); ?></td>
           </tr>
         </table></td>

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -142,15 +142,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE)) . "\n";
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value))) . "\n";
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_name[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_url[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_name[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_description[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_url[$languages[$i]['id']])));
       }
       echo zen_draw_hidden_field('products_image', stripslashes($products_image_name));
       echo ( (isset($_GET['search']) && !empty($_GET['search'])) ? zen_draw_hidden_field('search', $_GET['search']) : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? zen_draw_hidden_field('search', $_POST['search']) : '');

--- a/admin/includes/modules/product/preview_info_meta_tags.php
+++ b/admin/includes/modules/product/preview_info_meta_tags.php
@@ -108,15 +108,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_title[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_keywords[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_title[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_keywords[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_description[$languages[$i]['id']])));
       }
 
       echo zen_image_submit('button_back.gif', IMAGE_BACK, 'name="edit"') . '&nbsp;&nbsp;';

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -303,7 +303,7 @@ echo zen_draw_hidden_field('products_price_sorter', $pInfo->products_price_sorte
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_PRODUCTS_NAME; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
           </tr>
 <?php
     }
@@ -405,7 +405,7 @@ updateGross();
             <td colspan="2"><table border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td class="main" width="25" valign="top"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>&nbsp;</td>
-                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', htmlspecialchars((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
+                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', zen_output_string_protected((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id'])), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
               </tr>
             </table></td>
           </tr>
@@ -424,7 +424,7 @@ updateGross();
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_PRODUCTS_MODEL; ?></td>
-            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', htmlspecialchars(stripslashes($pInfo->products_model), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
+            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', zen_output_string_protected(stripslashes($pInfo->products_model)), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -467,7 +467,7 @@ updateGross();
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_PRODUCTS_URL . '<br /><small>' . TEXT_PRODUCTS_URL_WITHOUT_HTTP . '</small>'; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url')); ?></td>
           </tr>
 <?php
     }

--- a/admin/includes/modules/product_free_shipping/collect_info_metatags.php
+++ b/admin/includes/modules/product_free_shipping/collect_info_metatags.php
@@ -150,19 +150,19 @@ echo zen_draw_form('new_product_meta_tags', $type_admin_handler , 'cPath=' . $cP
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
+              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
         </table></td>

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -143,15 +143,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_name[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_url[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_name[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_description[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_url[$languages[$i]['id']])));
       }
       echo zen_draw_hidden_field('products_image', stripslashes($products_image_name));
       echo ( (isset($_GET['search']) && !empty($_GET['search'])) ? zen_draw_hidden_field('search', $_GET['search']) : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? zen_draw_hidden_field('search', $_POST['search']) : '');

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -55,7 +55,7 @@ if (!defined('IS_ADMIN_FLAG')) {
       <tr>
         <td><table border="0" width="100%" cellspacing="0" cellpadding="0">
           <tr>
-            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_output_string_protected($pInfo->products_name); ?></td>
+            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . htmlspecialchars($pInfo->products_name, ENT_COMPAT, CHARSET, FALSE); ?></td>
             <td class="pageHeading" align="right"><?php echo $currencies->format($pInfo->products_price) . ($pInfo->products_virtual == 1 ? '<span class="errorText">' . '<br />' . TEXT_VIRTUAL_PREVIEW . '</span>' : '') . ($pInfo->product_is_always_free_shipping == 1 ? '<span class="errorText">' . '<br />' . TEXT_FREE_SHIPPING_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_PRICED_BY_ATTRIBUTES_PREVIEW . '</span>' : '') . ($pInfo->product_is_free == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_FREE_PREVIEW . '</span>' : '') . ($pInfo->product_is_call == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_CALL_PREVIEW . '</span>' : '') . ($pInfo->products_qty_box_status == 0 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_QTY_BOX_STATUS_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<br />' . zen_get_products_display_price($_GET['pID']) : ''); ?></td>
           </tr>
         </table></td>

--- a/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
@@ -107,15 +107,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_title[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_keywords[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_title[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_keywords[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_description[$languages[$i]['id']])));
       }
 
       echo zen_image_submit('button_back.gif', IMAGE_BACK, 'name="edit"') . '&nbsp;&nbsp;';

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -330,7 +330,7 @@ echo zen_draw_hidden_field('products_price_sorter', $pInfo->products_price_sorte
 ?>
           <tr>
             <td class="main"><?php if ($i == 0) echo TEXT_PRODUCTS_NAME; ?></td>
-            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
+            <td class="main"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($products_name[$languages[$i]['id']]) ? stripslashes($products_name[$languages[$i]['id']]) : zen_get_products_name($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_name')); ?></td>
           </tr>
 <?php
     }
@@ -432,7 +432,7 @@ updateGross();
             <td colspan="2"><table border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td class="main" width="25" valign="top"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>&nbsp;</td>
-                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', htmlspecialchars((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
+                <td class="main" width="100%"><?php echo zen_draw_textarea_field('products_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '30', zen_output_string_protected((isset($products_description[$languages[$i]['id']])) ? stripslashes($products_description[$languages[$i]['id']]) : zen_get_products_description($pInfo->products_id, $languages[$i]['id'])), 'class="editorHook"'); //,'id="'.'products_description' . $languages[$i]['id'] . '"'); ?></td>
               </tr>
             </table></td>
           </tr>
@@ -451,7 +451,7 @@ updateGross();
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_PRODUCTS_MODEL; ?></td>
-            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', htmlspecialchars(stripslashes($pInfo->products_model), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
+            <td class="main"><?php echo zen_draw_separator('pixel_trans.gif', '24', '15') . '&nbsp;' . zen_draw_input_field('products_model', zen_output_string_protected(stripslashes($pInfo->products_model)), zen_set_field_length(TABLE_PRODUCTS, 'products_model')); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>

--- a/admin/includes/modules/product_music/collect_info_metatags.php
+++ b/admin/includes/modules/product_music/collect_info_metatags.php
@@ -150,19 +150,19 @@ echo zen_draw_form('new_product_meta_tags', $type_admin_handler , 'cPath=' . $cP
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
+              <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_metatags_title($pInfo->products_id, $languages[$i]['id'])), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false)); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"');?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_keywords[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_keywords[$languages[$i]['id']])) ? stripslashes($metatags_keywords[$languages[$i]['id']]) : zen_get_metatags_keywords($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_keywords' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
           <tr>
             <td class="main"valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
             <td class="main">
-              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', htmlspecialchars((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
+              <?php echo zen_draw_textarea_field('metatags_description[' . $languages[$i]['id'] . ']', 'soft', '100%', '10', zen_output_string_protected((isset($metatags_description[$languages[$i]['id']])) ? stripslashes($metatags_description[$languages[$i]['id']]) : zen_get_metatags_description($pInfo->products_id, $languages[$i]['id'])), 'class="noEditor"'); //,'id="'.'metatags_description' . $languages[$i]['id'] . '"'); ?>
             </td>
           </tr>
         </table></td>

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -132,15 +132,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_name[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($products_url[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('products_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_name[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_description[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('products_url[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($products_url[$languages[$i]['id']])));
       }
       echo zen_draw_hidden_field('products_image', stripslashes($products_image_name));
       echo ( (isset($_GET['search']) && !empty($_GET['search'])) ? zen_draw_hidden_field('search', $_GET['search']) : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? zen_draw_hidden_field('search', $_POST['search']) : '');

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -56,7 +56,7 @@ if (!defined('IS_ADMIN_FLAG')) {
       <tr>
         <td><table border="0" width="100%" cellspacing="0" cellpadding="0">
           <tr>
-            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_output_string_protected($pInfo->products_name); ?></td>
+            <td class="pageHeading"><?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . htmlspecialchars($pInfo->products_name, ENT_COMPAT, CHARSET, FALSE); ?></td>
             <td class="pageHeading" align="right"><?php echo $currencies->format($pInfo->products_price) . ($pInfo->products_virtual == 1 ? '<span class="errorText">' . '<br />' . TEXT_VIRTUAL_PREVIEW . '</span>' : '') . ($pInfo->product_is_always_free_shipping == 1 ? '<span class="errorText">' . '<br />' . TEXT_FREE_SHIPPING_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_PRICED_BY_ATTRIBUTES_PREVIEW . '</span>' : '') . ($pInfo->product_is_free == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_FREE_PREVIEW . '</span>' : '') . ($pInfo->product_is_call == 1 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_IS_CALL_PREVIEW . '</span>' : '') . ($pInfo->products_qty_box_status == 0 ? '<span class="errorText">' . '<br />' . TEXT_PRODUCTS_QTY_BOX_STATUS_PREVIEW . '</span>' : '') . ($pInfo->products_priced_by_attribute == 1 ? '<br />' . zen_get_products_display_price($_GET['pID']) : ''); ?></td>
           </tr>
         </table></td>

--- a/admin/includes/modules/product_music/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_music/preview_info_meta_tags.php
@@ -107,15 +107,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       reset($_POST);
       while (list($key, $value) = each($_POST)) {
         if (!is_array($_POST[$key])) {
-          echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
+          echo zen_draw_hidden_field($key, zen_output_string_protected(stripslashes($value)));
         }
       }
 
       $languages = zen_get_languages();
       for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_title[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_keywords[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
-        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', htmlspecialchars(stripslashes($metatags_description[$languages[$i]['id']]), ENT_COMPAT, CHARSET, TRUE));
+        echo zen_draw_hidden_field('metatags_title[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_title[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_keywords[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_keywords[$languages[$i]['id']])));
+        echo zen_draw_hidden_field('metatags_description[' . $languages[$i]['id'] . ']', zen_output_string_protected(stripslashes($metatags_description[$languages[$i]['id']])));
       }
 
       echo zen_image_submit('button_back.gif', IMAGE_BACK, 'name="edit"') . '&nbsp;&nbsp;';

--- a/admin/includes/template/partials/leadInputTypes/tplCheckbox.php
+++ b/admin/includes/template/partials/leadInputTypes/tplCheckbox.php
@@ -13,7 +13,7 @@
        style="width:auto"
        type="checkbox"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        >
 <?php if ($tplVars['leadDefinition']['action'] != 'list') { ?>
 <small class="error"><?php echo $tplVars['leadDefinition']['fields'][$field]['validations']['errorText']; ?></small>

--- a/admin/includes/template/partials/leadInputTypes/tplCheckbox.php
+++ b/admin/includes/template/partials/leadInputTypes/tplCheckbox.php
@@ -13,7 +13,7 @@
        style="width:auto"
        type="checkbox"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo zen_output_string_protected($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        >
 <?php if ($tplVars['leadDefinition']['action'] != 'list') { ?>
 <small class="error"><?php echo $tplVars['leadDefinition']['fields'][$field]['validations']['errorText']; ?></small>

--- a/admin/includes/template/partials/leadInputTypes/tplFile.php
+++ b/admin/includes/template/partials/leadInputTypes/tplFile.php
@@ -14,14 +14,14 @@
        style="width:auto"
        type="file"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo zen_output_string_protected($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        <?php echo ($tplVars['leadDefinition']['fields'][$field]['validations']['required']) ? ' required ' : ''; ?>
        ><br>
        <?php if (isset($tplVars['leadDefinition']['fields'][$field]['layout']['uploadOptions']['imageDirectorySelector']) && $tplVars['leadDefinition']['fields'][$field]['layout']['uploadOptions']['imageDirectorySelector']) { ?>
           <?php echo zen_draw_pull_down_menu($tplVars['leadDefinition']['fields'][$field]['field'].'_file_select', $tplVars['leadDefinition']['fields'][$field]['layout']['uploadOptions']['imageDirectorySelectList']); ?>
        <?php }?>
 
-       <?php echo '&nbsp;' . htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE);?><br><?php echo zen_info_image($tplVars['leadDefinition']['fields'][$field]['value'], '', 100); ?><br>
+       <?php echo '&nbsp;' . zen_output_string_protected($tplVars['leadDefinition']['fields'][$field]['value']);?><br><?php echo zen_info_image($tplVars['leadDefinition']['fields'][$field]['value'], '', 100); ?><br>
        <?php if ($tplVars['leadDefinition']['action'] != 'list') { ?>
 <small class="error"><?php echo $tplVars['leadDefinition']['fields'][$field]['validations']['errorText']; ?></small>
 <?php   if ($tplVars['leadDefinition']['fields'][$field]['autocomplete']) { ?>

--- a/admin/includes/template/partials/leadInputTypes/tplFile.php
+++ b/admin/includes/template/partials/leadInputTypes/tplFile.php
@@ -14,14 +14,14 @@
        style="width:auto"
        type="file"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        <?php echo ($tplVars['leadDefinition']['fields'][$field]['validations']['required']) ? ' required ' : ''; ?>
        ><br>
        <?php if (isset($tplVars['leadDefinition']['fields'][$field]['layout']['uploadOptions']['imageDirectorySelector']) && $tplVars['leadDefinition']['fields'][$field]['layout']['uploadOptions']['imageDirectorySelector']) { ?>
           <?php echo zen_draw_pull_down_menu($tplVars['leadDefinition']['fields'][$field]['field'].'_file_select', $tplVars['leadDefinition']['fields'][$field]['layout']['uploadOptions']['imageDirectorySelectList']); ?>
        <?php }?>
 
-       <?php echo '&nbsp;' . htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value']);?><br><?php echo zen_info_image($tplVars['leadDefinition']['fields'][$field]['value'], '', 100); ?><br>
+       <?php echo '&nbsp;' . htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE);?><br><?php echo zen_info_image($tplVars['leadDefinition']['fields'][$field]['value'], '', 100); ?><br>
        <?php if ($tplVars['leadDefinition']['action'] != 'list') { ?>
 <small class="error"><?php echo $tplVars['leadDefinition']['fields'][$field]['validations']['errorText']; ?></small>
 <?php   if ($tplVars['leadDefinition']['fields'][$field]['autocomplete']) { ?>

--- a/admin/includes/template/partials/leadInputTypes/tplHidden.php
+++ b/admin/includes/template/partials/leadInputTypes/tplHidden.php
@@ -13,5 +13,5 @@
        style="width:auto"
        type="hidden"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo zen_output_string_protected($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        >

--- a/admin/includes/template/partials/leadInputTypes/tplHidden.php
+++ b/admin/includes/template/partials/leadInputTypes/tplHidden.php
@@ -13,5 +13,5 @@
        style="width:auto"
        type="hidden"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        >

--- a/admin/includes/template/partials/leadInputTypes/tplSelect.php
+++ b/admin/includes/template/partials/leadInputTypes/tplSelect.php
@@ -13,9 +13,9 @@
   style="width: auto" name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>">
 <?php foreach ($tplVars['leadDefinition']['fields'][$field]['layout']['options'] as $option) { ?>
 <option
-    value="<?php echo zen_output_string_protected($option['id']); ?>"
+    value="<?php echo htmlspecialchars($option['id'], ENT_COMPAT, CHARSET, FALSE); ?>"
     <?php if ($tplVars['leadDefinition']['fields'][$field]['value'] == $option['id']) echo ' selected="selected" '; ?>>
-    <?php echo zen_output_string_protected($option['text']); ?>
+    <?php echo htmlspecialchars($option['text'], ENT_COMPAT, CHARSET, FALSE); ?>
 </option>
 <?php } ?>
 </select>

--- a/admin/includes/template/partials/leadInputTypes/tplText.php
+++ b/admin/includes/template/partials/leadInputTypes/tplText.php
@@ -14,7 +14,7 @@
        style="width:auto"
        type="text"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo zen_output_string_protected($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        <?php if ($tplVars['leadDefinition']['fields'][$field]['validations']['pattern'] !="") echo ' pattern="' . $tplVars['leadDefinition']['fields'][$field]['validations']['pattern'] . '"'; ?>
        <?php echo ($tplVars['leadDefinition']['fields'][$field]['validations']['required']) ? ' required ' : ''; ?>
        >

--- a/admin/includes/template/partials/leadInputTypes/tplText.php
+++ b/admin/includes/template/partials/leadInputTypes/tplText.php
@@ -14,7 +14,7 @@
        style="width:auto"
        type="text"
        name="<?php echo $tplVars['leadDefinition']['fields'][$field]['field']; ?>"
-       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value']); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
+       value="<?php echo htmlspecialchars($tplVars['leadDefinition']['fields'][$field]['value'], ENT_COMPAT, CHARSET, TRUE); ?>" size="<?php echo $tplVars['leadDefinition']['fields'][$field]['layout']['size']; ?>"
        <?php if ($tplVars['leadDefinition']['fields'][$field]['validations']['pattern'] !="") echo ' pattern="' . $tplVars['leadDefinition']['fields'][$field]['validations']['pattern'] . '"'; ?>
        <?php echo ($tplVars['leadDefinition']['fields'][$field]['validations']['required']) ? ' required ' : ''; ?>
        >

--- a/admin/includes/template/templates/tplIndexStartWizard.php
+++ b/admin/includes/template/templates/tplIndexStartWizard.php
@@ -41,7 +41,7 @@
   <label class="inline" for="store_name"><?php echo TEXT_FORM_LABEL_STORE_NAME; ?></label>
   </div>
   <div class="small-9 columns">
-  <input type="text" id="store_name" name="store_name" value="<?php echo zen_output_string_protected($tplVars['storeName']); ?>" autofocus="autofocus" tabindex="1" placeholder="<?php echo TEXT_EXAMPLE_STORENAME; ?>">
+  <input type="text" id="store_name" name="store_name" value="<?php echo htmlspecialchars($tplVars['storeName'], ENT_COMPAT, CHARSET, FALSE); ?>" autofocus="autofocus" tabindex="1" placeholder="<?php echo TEXT_EXAMPLE_STORENAME; ?>">
   </div>
    </div>
 
@@ -50,7 +50,7 @@
    <label class="inline" for="store_owner"><?php echo TEXT_FORM_LABEL_STORE_OWNER; ?></label>
    </div>
   <div class="small-9 columns">
-    <input type="text" id="store_owner" name="store_owner" value="<?php echo zen_output_string_protected($tplVars['storeOwner']); ?>" tabindex="2" placeholder="<?php echo TEXT_EXAMPLE_STOREOWNER; ?>">
+    <input type="text" id="store_owner" name="store_owner" value="<?php echo htmlspecialchars($tplVars['storeOwner'], ENT_COMPAT, CHARSET, FALSE); ?>" tabindex="2" placeholder="<?php echo TEXT_EXAMPLE_STOREOWNER; ?>">
    </div>
    </div>
 
@@ -59,7 +59,7 @@
    <label class="inline" for="store_owner_email"><?php echo TEXT_FORM_LABEL_STORE_OWNER_EMAIL; ?></label>
    </div>
   <div class="small-9 columns">
-   <input type="text" id="store_owner_email" name="store_owner_email" value="<?php echo zen_output_string_protected($tplVars['storeOwnerEmail']); ?>" tabindex="3" placeholder="webmaster@example.com">
+   <input type="text" id="store_owner_email" name="store_owner_email" value="<?php echo htmlspecialchars($tplVars['storeOwnerEmail'], ENT_COMPAT, CHARSET, FALSE); ?>" tabindex="3" placeholder="webmaster@example.com">
    </div>
    </div>
 

--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -167,7 +167,7 @@ function couponpopupWindow(url) {
 
       if (isset($order->products[$i]['attributes']) && (($k = sizeof($order->products[$i]['attributes'])) > 0)) {
         for ($j = 0; $j < $k; $j++) {
-          echo '<br><nobr><small>&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(zen_output_string_protected($order->products[$i]['attributes'][$j]['value']));
+          echo '<br><nobr><small>&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(htmlspecialchars($order->products[$i]['attributes'][$j]['value'], ENT_COMPAT, CHARSET, FALSE));
           if ($order->products[$i]['attributes'][$j]['price'] != '0') echo ' (' . $order->products[$i]['attributes'][$j]['prefix'] . $currencies->format($order->products[$i]['attributes'][$j]['price'] * $order->products[$i]['qty'], true, $order->info['currency'], $order->info['currency_value']) . ')';
           if ($order->products[$i]['attributes'][$j]['product_attribute_is_free'] == '1' and $order->products[$i]['product_is_free'] == '1') echo TEXT_INFO_ATTRIBUTE_FREE;
           echo '</i></small></nobr>';

--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -232,7 +232,7 @@ function couponpopupWindow(url) {
         echo '          <tr>' . "\n" .
              '            <td class="smallText" align="center" valign="top">' . zen_datetime_short($orders_history->fields['date_added']) . '</td>' . "\n";
         echo '            <td class="smallText" valign="top">' . $orders_status_array[$orders_history->fields['orders_status_id']] . '</td>' . "\n";
-        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(zen_db_output($orders_history->fields['comments']))) . '&nbsp;</td>' . "\n" .
+        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(htmlspecialchars($orders_history->fields['comments'], ENT_COMPAT, CHARSET, TRUE))) . '&nbsp;</td>' . "\n" .
              '          </tr>' . "\n";
         $orders_history->MoveNext();
         if (ORDER_COMMENTS_INVOICE == 1 && $count_comments >= 1) {

--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -232,7 +232,7 @@ function couponpopupWindow(url) {
         echo '          <tr>' . "\n" .
              '            <td class="smallText" align="center" valign="top">' . zen_datetime_short($orders_history->fields['date_added']) . '</td>' . "\n";
         echo '            <td class="smallText" valign="top">' . $orders_status_array[$orders_history->fields['orders_status_id']] . '</td>' . "\n";
-        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(htmlspecialchars($orders_history->fields['comments'], ENT_COMPAT, CHARSET, TRUE))) . '&nbsp;</td>' . "\n" .
+        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(zen_output_string_protected($orders_history->fields['comments']))) . '&nbsp;</td>' . "\n" .
              '          </tr>' . "\n";
         $orders_history->MoveNext();
         if (ORDER_COMMENTS_INVOICE == 1 && $count_comments >= 1) {

--- a/admin/mail.php
+++ b/admin/mail.php
@@ -219,10 +219,10 @@ function check_form(form_name) {
               <td class="smallText"><b><?php echo TEXT_CUSTOMER; ?></b>&nbsp;&nbsp;&nbsp;<?php echo $mail_sent_to; ?></td>
             </tr>
             <tr>
-              <td class="smallText"><b><?php echo TEXT_FROM; ?></b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo htmlspecialchars(stripslashes($_POST['from']), ENT_COMPAT, CHARSET, TRUE); ?></td>
+              <td class="smallText"><b><?php echo TEXT_FROM; ?></b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo zen_output_string_protected(stripslashes($_POST['from'])); ?></td>
             </tr>
             <tr>
-              <td class="smallText"><b><?php echo TEXT_SUBJECT; ?></b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo htmlspecialchars(stripslashes($_POST['subject']), ENT_COMPAT, CHARSET, TRUE); ?></td>
+              <td class="smallText"><b><?php echo TEXT_SUBJECT; ?></b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo zen_output_string_protected(stripslashes($_POST['subject'])); ?></td>
             </tr>
             <tr>
               <td class="smallText"><b><hr /><?php echo strip_tags(TEXT_MESSAGE_HTML); ?></b></td>
@@ -242,7 +242,7 @@ function check_form(form_name) {
   $message_preview = (stristr($message_preview, '<br') ? $message_preview : nl2br($message_preview));
   $message_preview = str_replace(array('<br>','<br />'), "<br />\n", $message_preview);
   $message_preview = str_replace('</p>', "</p>\n", $message_preview);
-  echo '<tt>' . nl2br(htmlspecialchars(stripslashes(strip_tags($message_preview)), ENT_COMPAT, CHARSET, TRUE) ) . '</tt>';
+  echo '<tt>' . nl2br(zen_output_string_protected(stripslashes(strip_tags($message_preview))) ) . '</tt>';
 ?>
                 <hr />
               </td>
@@ -298,14 +298,14 @@ function check_form(form_name) {
             </tr>
             <tr>
               <td class="main"><?php echo TEXT_FROM; ?></td>
-              <td><?php echo zen_draw_input_field('from', htmlspecialchars(EMAIL_FROM, ENT_COMPAT, CHARSET, TRUE), 'size="50"'); ?></td>
+              <td><?php echo zen_draw_input_field('from', zen_output_string_protected(EMAIL_FROM), 'size="50"'); ?></td>
             </tr>
             <tr>
               <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
             </tr>
             <tr>
               <td class="main"><?php echo TEXT_SUBJECT; ?></td>
-              <td><?php echo zen_draw_input_field('subject', htmlspecialchars($_POST['subject'], ENT_COMPAT, CHARSET, TRUE), 'size="50"'); ?></td>
+              <td><?php echo zen_draw_input_field('subject', zen_output_string_protected($_POST['subject']), 'size="50"'); ?></td>
             </tr>
             <tr>
               <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
@@ -315,7 +315,7 @@ function check_form(form_name) {
               <td class="main" width="750">
 <?php if (EMAIL_USE_HTML != 'true') echo TEXT_WARNING_HTML_DISABLED; ?>
 <?php if (EMAIL_USE_HTML == 'true') {
-  echo zen_draw_textarea_field('message_html', 'soft', '100%', '25', htmlspecialchars(stripslashes($_POST['message_html']), ENT_COMPAT, CHARSET, TRUE), 'id="message_html" class="editorHook"');
+  echo zen_draw_textarea_field('message_html', 'soft', '100%', '25', zen_output_string_protected(stripslashes($_POST['message_html'])), 'id="message_html" class="editorHook"');
 } ?>
               </td>
             </tr>
@@ -324,7 +324,7 @@ function check_form(form_name) {
             </tr>
             <tr>
               <td valign="top" class="main"><?php echo TEXT_MESSAGE; ?></td>
-              <td><?php echo zen_draw_textarea_field('message', 'soft', '100%', '15', htmlspecialchars($_POST['message'], ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); ?></td>
+              <td><?php echo zen_draw_textarea_field('message', 'soft', '100%', '15', zen_output_string_protected($_POST['message']), 'class="noEditor"'); ?></td>
             </tr>
 
 <?php if (defined('EMAIL_ATTACHMENTS_ENABLED') && EMAIL_ATTACHMENTS_ENABLED === true && defined('DIR_WS_ADMIN_ATTACHMENTS') && is_dir(DIR_WS_ADMIN_ATTACHMENTS) && is_writable(DIR_WS_ADMIN_ATTACHMENTS) ) { ?>

--- a/admin/mail.php
+++ b/admin/mail.php
@@ -68,7 +68,7 @@
     } else {
       $messageStack->add_session(sprintf(NOTICE_EMAIL_FAILED_SEND, $mail_sent_to .  ' (' . $recip_count . ')'), 'error');
     }
-    zen_redirect(zen_href_link(FILENAME_MAIL, 'mail_sent_to=' . urlencode($mail_sent_to) . '&recip_count='. $recip_count  . (isset($_GET['origin']) ? '&origin='.zen_output_string_protected($_GET['origin']): '') . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer='.zen_output_string_protected($_GET['customer']): '')));
+    zen_redirect(zen_href_link(FILENAME_MAIL, 'mail_sent_to=' . urlencode($mail_sent_to) . '&recip_count='. $recip_count  . (isset($_GET['origin']) ? '&origin='.htmlspecialchars($_GET['origin'], ENT_COMPAT, CHARSET, FALSE): '') . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer='.htmlspecialchars($_GET['customer'], ENT_COMPAT, CHARSET, FALSE): '')));
   }
 
   if ( EMAIL_ATTACHMENTS_ENABLED && $action == 'preview') {
@@ -230,7 +230,7 @@ function check_form(form_name) {
             <tr>
               <td width="500">
 <?php if (EMAIL_USE_HTML != 'true') echo TEXT_WARNING_HTML_DISABLED.'<br />'; ?>
-<?php $html_preview = zen_output_string_protected($_POST['message_html']); echo (stristr($html_preview, '<br') ? $html_preview : nl2br($html_preview)); ?><hr /></td>
+<?php $html_preview = htmlspecialchars($_POST['message_html'], ENT_COMPAT, CHARSET, FALSE); echo (stristr($html_preview, '<br') ? $html_preview : nl2br($html_preview)); ?><hr /></td>
             </tr>
             <tr>
               <td class="smallText"><b><?php echo strip_tags(TEXT_MESSAGE); ?></b><br /></td>
@@ -255,7 +255,7 @@ function check_form(form_name) {
             <tr>
               <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
             </tr>
-            <tr><?php echo zen_draw_form('mail', FILENAME_MAIL, 'action=send_email_to_user' . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer='.zen_output_string_protected($_GET['customer']): '') . (isset($_GET['origin']) ? '&origin='.zen_output_string_protected($_GET['origin']): '')); ?>
+            <tr><?php echo zen_draw_form('mail', FILENAME_MAIL, 'action=send_email_to_user' . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer='.htmlspecialchars($_GET['customer'], ENT_COMPAT, CHARSET, FALSE): '') . (isset($_GET['origin']) ? '&origin='.htmlspecialchars($_GET['origin'], ENT_COMPAT, CHARSET, FALSE): '')); ?>
               <td>
 <?php
   /* Re-Post all POST'ed variables */
@@ -272,7 +272,7 @@ function check_form(form_name) {
                 <table border="0" width="100%" cellpadding="0" cellspacing="2">
                   <tr>
                     <td><?php echo zen_image_submit('button_back.gif', IMAGE_BACK, 'name="back"'); ?></td>
-                    <td align="right"><?php echo '<a href="' . zen_href_link(FILENAME_MAIL, 'cID=' . zen_db_prepare_input($_GET['cID']) . (isset($_GET['customer']) ? '&customer=' . zen_output_string_protected($_GET['customer']) : '') . (isset($_GET['origin']) ? '&origin='.zen_output_string_protected($_GET['origin']): '')) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a> ' . zen_image_submit('button_send_mail.gif', IMAGE_SEND_EMAIL); ?></td>
+                    <td align="right"><?php echo '<a href="' . zen_href_link(FILENAME_MAIL, 'cID=' . zen_db_prepare_input($_GET['cID']) . (isset($_GET['customer']) ? '&customer=' . htmlspecialchars($_GET['customer'], ENT_COMPAT, CHARSET, FALSE) : '') . (isset($_GET['origin']) ? '&origin='.htmlspecialchars($_GET['origin'], ENT_COMPAT, CHARSET, FALSE): '')) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a> ' . zen_image_submit('button_send_mail.gif', IMAGE_SEND_EMAIL); ?></td>
                   </tr>
                 </table></td>
               </tr>
@@ -281,7 +281,7 @@ function check_form(form_name) {
 <?php
 } else {
 ?>
-            <tr><?php echo zen_draw_form('mail', FILENAME_MAIL,'action=preview' . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer='.zen_output_string_protected($_GET['customer']): '') . (isset($_GET['origin']) ? '&origin='.zen_output_string_protected($_GET['origin']): ''), 'post', 'onsubmit="return check_form(mail);" enctype="multipart/form-data"'); ?>
+            <tr><?php echo zen_draw_form('mail', FILENAME_MAIL,'action=preview' . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer='.htmlspecialchars($_GET['customer'], ENT_COMPAT, CHARSET, FALSE): '') . (isset($_GET['origin']) ? '&origin='.htmlspecialchars($_GET['origin'], ENT_COMPAT, CHARSET, FALSE): ''), 'post', 'onsubmit="return check_form(mail);" enctype="multipart/form-data"'); ?>
               <td><table border="0" cellpadding="0" cellspacing="2">
             <tr>
               <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>

--- a/admin/manufacturers.php
+++ b/admin/manufacturers.php
@@ -254,7 +254,7 @@ if (($_GET['page'] == '' or $_GET['page'] == '1') and $_GET['mID'] != '') {
 
       $contents = array('form' => zen_draw_form('manufacturers', FILENAME_MANUFACTURERS, 'page=' . $_GET['page'] . '&mID=' . $mInfo->manufacturers_id . '&action=save', 'post', 'enctype="multipart/form-data"'));
       $contents[] = array('text' => TEXT_EDIT_INTRO);
-      $contents[] = array('text' => '<br />' . TEXT_MANUFACTURERS_NAME . '<br>' . zen_draw_input_field('manufacturers_name', htmlspecialchars($mInfo->manufacturers_name, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_MANUFACTURERS, 'manufacturers_name')));
+      $contents[] = array('text' => '<br />' . TEXT_MANUFACTURERS_NAME . '<br>' . zen_draw_input_field('manufacturers_name', zen_output_string_protected($mInfo->manufacturers_name), zen_set_field_length(TABLE_MANUFACTURERS, 'manufacturers_name')));
       $contents[] = array('text' => '<br />' . TEXT_MANUFACTURERS_IMAGE . '<br>' . zen_draw_file_field('manufacturers_image') . '<br />' . $mInfo->manufacturers_image);
       $dir_info = zen_build_subdirectories_array(DIR_FS_CATALOG_IMAGES);
       $default_directory = substr( $mInfo->manufacturers_image, 0,strpos( $mInfo->manufacturers_image, '/')+1);

--- a/admin/media_manager.php
+++ b/admin/media_manager.php
@@ -221,7 +221,7 @@ require('includes/admin_html_head.php');
 
       $contents[] = array('text' => zen_draw_form('collections', FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id . '&action=save', 'post', 'enctype="multipart/form-data"'));
       $contents[] = array('text' => TEXT_EDIT_INTRO);
-      $contents[] = array('text' => '<br />' . TEXT_MEDIA_COLLECTION_NAME . '<br>' . zen_draw_input_field('media_name', htmlspecialchars($mInfo->media_name, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_MEDIA_MANAGER, 'media_name')));
+      $contents[] = array('text' => '<br />' . TEXT_MEDIA_COLLECTION_NAME . '<br>' . zen_draw_input_field('media_name', zen_output_string_protected($mInfo->media_name), zen_set_field_length(TABLE_MEDIA_MANAGER, 'media_name')));
       $contents[] = array('align' => 'center', 'text' => '<br />' . zen_image_submit('button_save.gif', IMAGE_SAVE) . ' <a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a>');
 
       $contents[] = array('text' => zen_draw_separator('pixel_black.gif'));

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -326,7 +326,7 @@ require('includes/admin_html_head.php');
         if ($value['set_function']) {
           eval('$keys .= ' . $value['set_function'] . "'" . $value['value'] . "', '" . $key . "');");
         } else {
-          $keys .= zen_draw_input_field('configuration[' . $key . ']', htmlspecialchars($value['value'], ENT_COMPAT, CHARSET, TRUE));
+          $keys .= zen_draw_input_field('configuration[' . $key . ']', zen_output_string_protected($value['value']));
         }
         $keys .= '<br><br>';
       }

--- a/admin/newsletters.php
+++ b/admin/newsletters.php
@@ -218,18 +218,18 @@ check_select('audience_selected','',"<?php echo ERROR_PLEASE_SELECT_AUDIENCE; ?>
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_NEWSLETTER_TITLE; ?></td>
-            <td class="main"><?php echo zen_draw_input_field('title', htmlspecialchars($nInfo->title, ENT_COMPAT, CHARSET, TRUE), 'size="50"', true); ?></td>
+            <td class="main"><?php echo zen_draw_input_field('title', zen_output_string_protected($nInfo->title), 'size="50"', true); ?></td>
           </tr>
           <tr>
             <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_NEWSLETTER_CONTENT_HTML; ?></td>
-            <td class="main"><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '30', htmlspecialchars($nInfo->content_html, ENT_COMPAT, CHARSET, TRUE),'id="message_html" class="editorHook"'); ?></td>
+            <td class="main"><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '30', zen_output_string_protected($nInfo->content_html),'id="message_html" class="editorHook"'); ?></td>
           </tr>
           <tr>
             <td class="main" valign="top"><?php echo TEXT_NEWSLETTER_CONTENT; ?></td>
-            <td class="main"><?php echo zen_draw_textarea_field('content', 'soft', '100%', '20', htmlspecialchars($nInfo->content, ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); ?></td>
+            <td class="main"><?php echo zen_draw_textarea_field('content', 'soft', '100%', '20', zen_output_string_protected($nInfo->content), 'class="noEditor"'); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -685,7 +685,7 @@ function couponpopupWindow(url) {
           echo zen_image(DIR_WS_ICONS . 'unlocked.gif', TEXT_VISIBLE) . "</td>\n";
         }
         echo '            <td class="smallText">' . $orders_status_array[$orders_history->fields['orders_status_id']] . '</td>' . "\n";
-        echo '            <td class="smallText">' . nl2br(zen_db_output($orders_history->fields['comments'])) . '&nbsp;</td>' . "\n" .
+        echo '            <td class="smallText">' . nl2br(htmlspecialchars($orders_history->fields['comments'], ENT_COMPAT, CHARSET, TRUE)) . '&nbsp;</td>' . "\n" .
              '          </tr>' . "\n";
         $orders_history->MoveNext();
       }

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -607,7 +607,7 @@ function couponpopupWindow(url) {
 
       if (isset($order->products[$i]['attributes']) && (sizeof($order->products[$i]['attributes']) > 0)) {
         for ($j = 0, $k = sizeof($order->products[$i]['attributes']); $j < $k; $j++) {
-          echo '<br /><nobr><small>&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(zen_output_string_protected($order->products[$i]['attributes'][$j]['value']));
+          echo '<br /><nobr><small>&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(htmlspecialchars($order->products[$i]['attributes'][$j]['value'], ENT_COMPAT, CHARSET, FALSE));
           if ($order->products[$i]['attributes'][$j]['price'] != '0') echo ' (' . $order->products[$i]['attributes'][$j]['prefix'] . $currencies->format($order->products[$i]['attributes'][$j]['price'] * $order->products[$i]['qty'], true, $order->info['currency'], $order->info['currency_value']) . ')';
           if ($order->products[$i]['attributes'][$j]['product_attribute_is_free'] == '1' and $order->products[$i]['product_is_free'] == '1') echo TEXT_INFO_ATTRIBUTE_FREE;
           echo '</i></small></nobr>';
@@ -1017,7 +1017,7 @@ if (($_GET['page'] == '' or $_GET['page'] <= 1) and $_GET['oID'] != '') {
 
         if (sizeof($order->products[$i]['attributes']) > 0) {
           for ($j=0; $j<sizeof($order->products[$i]['attributes']); $j++) {
-            $contents[] = array('text' => '&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(zen_output_string_protected($order->products[$i]['attributes'][$j]['value'])) . '</i></nobr>' );
+            $contents[] = array('text' => '&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(htmlspecialchars($order->products[$i]['attributes'][$j]['value'], ENT_COMPAT, CHARSET, FALSE)) . '</i></nobr>' );
           }
         }
         if ($i > MAX_DISPLAY_RESULTS_ORDERS_DETAILS_LISTING and MAX_DISPLAY_RESULTS_ORDERS_DETAILS_LISTING != 0) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -685,7 +685,7 @@ function couponpopupWindow(url) {
           echo zen_image(DIR_WS_ICONS . 'unlocked.gif', TEXT_VISIBLE) . "</td>\n";
         }
         echo '            <td class="smallText">' . $orders_status_array[$orders_history->fields['orders_status_id']] . '</td>' . "\n";
-        echo '            <td class="smallText">' . nl2br(htmlspecialchars($orders_history->fields['comments'], ENT_COMPAT, CHARSET, TRUE)) . '&nbsp;</td>' . "\n" .
+        echo '            <td class="smallText">' . nl2br(zen_output_string_protected($orders_history->fields['comments'])) . '&nbsp;</td>' . "\n" .
              '          </tr>' . "\n";
         $orders_history->MoveNext();
       }

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -151,7 +151,7 @@
 
       if (isset($order->products[$i]['attributes']) && (sizeof($order->products[$i]['attributes']) > 0)) {
         for ($j=0, $k=sizeof($order->products[$i]['attributes']); $j<$k; $j++) {
-          echo '<br><nobr><small>&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(zen_output_string_protected($order->products[$i]['attributes'][$j]['value']));
+          echo '<br><nobr><small>&nbsp;<i> - ' . $order->products[$i]['attributes'][$j]['option'] . ': ' . nl2br(htmlspecialchars($order->products[$i]['attributes'][$j]['value'], ENT_COMPAT, CHARSET, FALSE));
           echo '</i></small></nobr>';
         }
       }

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -185,7 +185,7 @@
         echo '          <tr>' . "\n" .
              '            <td class="smallText" align="center" valign="top">' . zen_datetime_short($orders_history->fields['date_added']) . '</td>' . "\n";
         echo '            <td class="smallText" valign="top">' . $orders_status_array[$orders_history->fields['orders_status_id']] . '</td>' . "\n";
-        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(zen_db_output($orders_history->fields['comments']))) . '&nbsp;</td>' . "\n" .
+        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(htmlspecialchars($orders_history->fields['comments'], ENT_COMPAT, CHARSET, TRUE))) . '&nbsp;</td>' . "\n" .
              '          </tr>' . "\n";
         $orders_history->MoveNext();
         if (ORDER_COMMENTS_PACKING_SLIP == 1 && $count_comments >= 1) {

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -185,7 +185,7 @@
         echo '          <tr>' . "\n" .
              '            <td class="smallText" align="center" valign="top">' . zen_datetime_short($orders_history->fields['date_added']) . '</td>' . "\n";
         echo '            <td class="smallText" valign="top">' . $orders_status_array[$orders_history->fields['orders_status_id']] . '</td>' . "\n";
-        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(htmlspecialchars($orders_history->fields['comments'], ENT_COMPAT, CHARSET, TRUE))) . '&nbsp;</td>' . "\n" .
+        echo '            <td class="smallText" valign="top">' . ($orders_history->fields['comments'] == '' ? TEXT_NONE : nl2br(zen_output_string_protected($orders_history->fields['comments']))) . '&nbsp;</td>' . "\n" .
              '          </tr>' . "\n";
         $orders_history->MoveNext();
         if (ORDER_COMMENTS_PACKING_SLIP == 1 && $count_comments >= 1) {

--- a/admin/product.php
+++ b/admin/product.php
@@ -160,7 +160,7 @@ require('includes/admin_html_head.php');
         $category_inputs_string = '';
         $languages = zen_get_languages();
         for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
-          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', htmlspecialchars(zen_get_category_name($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
+          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(zen_get_category_name($cInfo->categories_id, $languages[$i]['id'])), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
         }
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_NAME . $category_inputs_string);
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_IMAGE . '<br />' . zen_draw_file_field('categories_image'));

--- a/admin/product_free_shipping.php
+++ b/admin/product_free_shipping.php
@@ -154,7 +154,7 @@ require('includes/admin_html_head.php');
         $category_inputs_string = '';
         $languages = zen_get_languages();
         for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
-          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', htmlspecialchars(zen_get_category_name($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
+          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(zen_get_category_name($cInfo->categories_id, $languages[$i]['id'])), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
         }
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_NAME . $category_inputs_string);
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_IMAGE . '<br />' . zen_draw_file_field('categories_image'));

--- a/admin/product_music.php
+++ b/admin/product_music.php
@@ -155,7 +155,7 @@ require('includes/admin_html_head.php');
         $category_inputs_string = '';
         $languages = zen_get_languages();
         for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
-          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', htmlspecialchars(zen_get_category_name($cInfo->categories_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
+          $category_inputs_string .= '<br />' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . zen_draw_input_field('categories_name[' . $languages[$i]['id'] . ']', zen_output_string_protected(zen_get_category_name($cInfo->categories_id, $languages[$i]['id'])), zen_set_field_length(TABLE_CATEGORIES_DESCRIPTION, 'categories_name'));
         }
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_NAME . $category_inputs_string);
         $contents[] = array('text' => '<br />' . TEXT_EDIT_CATEGORIES_IMAGE . '<br />' . zen_draw_file_field('categories_image'));

--- a/admin/product_types.php
+++ b/admin/product_types.php
@@ -208,7 +208,7 @@ if ($_GET['action'] == 'layout' || $_GET['action'] == 'layout_edit') {
     }
 ?>
                 <td class="dataTableContent"><?php echo $configuration->fields['configuration_title']; ?></td>
-                <td class="dataTableContent"><?php echo htmlspecialchars($cfgValue, ENT_COMPAT, CHARSET, TRUE); ?></td>
+                <td class="dataTableContent"><?php echo zen_output_string_protected($cfgValue); ?></td>
                 <td class="dataTableContent" align="right"><?php if ( (isset($cInfo) && is_object($cInfo)) && ($configuration->fields['configuration_id'] == $cInfo->configuration_id) ) { echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', ''); } else { echo '<a href="' . zen_href_link(FILENAME_PRODUCT_TYPES, 'ptID=' . $_GET['ptID'] . '&cID=' . $configuration->fields['configuration_id'] . '&action=layout') . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>'; } ?>&nbsp;</td>
               </tr>
 <?php
@@ -225,9 +225,9 @@ if ($_GET['action'] == 'layout' || $_GET['action'] == 'layout_edit') {
       $heading[] = array('text' => '<b>' . $cInfo->configuration_title . '</b>');
 
       if ($cInfo->set_function) {
-        eval('$value_field = ' . $cInfo->set_function . '"' . htmlspecialchars($cInfo->configuration_value, ENT_COMPAT, CHARSET, TRUE) . '");');
+        eval('$value_field = ' . $cInfo->set_function . '"' . zen_output_string_protected($cInfo->configuration_value) . '");');
       } else {
-        $value_field = zen_draw_input_field('configuration_value', htmlspecialchars($cInfo->configuration_value, ENT_COMPAT, CHARSET, TRUE), 'size="60"');
+        $value_field = zen_draw_input_field('configuration_value', zen_output_string_protected($cInfo->configuration_value), 'size="60"');
       }
 
       $contents = array('form' => zen_draw_form('configuration', FILENAME_PRODUCT_TYPES, 'ptID=' . $_GET['ptID'] . '&cID=' . $cInfo->configuration_id . '&action=layout_save'));

--- a/admin/profiles.php
+++ b/admin/profiles.php
@@ -155,7 +155,7 @@ require('includes/admin_html_head.php');
           <?php echo zen_draw_form('profileNameForm', FILENAME_PROFILES, '', 'post', 'id="profile-update"') ?>
             <?php echo zen_draw_hidden_field('action', 'update_name'); ?>
             <?php echo zen_draw_hidden_field('profile', $profileDetails['id']); ?>
-            <?php echo zen_draw_input_field('profile-name', htmlspecialchars($profileDetails['name'], ENT_COMPAT, CHARSET, TRUE)); ?>
+            <?php echo zen_draw_input_field('profile-name', zen_output_string_protected($profileDetails['name'])); ?>
             <?php echo zen_image_submit('button_update.gif', IMAGE_UPDATE) ?>
             <a href="<?php echo zen_href_link(FILENAME_PROFILES) ?>"><?php echo zen_image_button('button_cancel.gif', IMAGE_CANCEL) ?></a>
           </form>
@@ -216,7 +216,7 @@ if ($action == 'delete' && $profileDetails['name'] == zen_get_profile_name($prof
         <input class="checkButton" type="button" value="<?php echo TEXT_UNCHECK_ALL; ?>" onclick="checkAll(this.form,'<?php echo $menuKey ?>',false);">
       </dt>
 <?php foreach ($pageList as $pageKey => $page) { ?>
-      <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), in_array($pageKey,$permittedPages), '', ' class="' . $menuKey . '"'); ?><?php echo htmlspecialchars($page['name'], ENT_COMPAT, CHARSET, FALSE); ?></label></dd>
+      <dd><label><?php echo zen_draw_checkbox_field('p[]', zen_output_string_protected($pageKey), in_array($pageKey,$permittedPages), '', ' class="' . $menuKey . '"'); ?><?php echo htmlspecialchars($page['name'], ENT_COMPAT, CHARSET, FALSE); ?></label></dd>
 <?php } ?>
     </dl>
 <?php } ?>
@@ -244,7 +244,7 @@ if ($action == 'delete' && $profileDetails['name'] == zen_get_profile_name($prof
         <input class="checkButton" type="button" value="<?php echo TEXT_UNCHECK_ALL; ?>" onclick="checkAll(this.form,'<?php echo $menuKey ?>',false);">
       </dt>
 <?php foreach ($pageList as $pageKey => $page) { ?>
-      <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), isset($_POST['p']) && in_array($pageKey, $_POST['p']), '', ' class="' . $menuKey . '"'); ?><?php echo htmlspecialchars($page['name'], ENT_COMPAT, CHARSET, FALSE); ?></label></dd>
+      <dd><label><?php echo zen_draw_checkbox_field('p[]', zen_output_string_protected($pageKey), isset($_POST['p']) && in_array($pageKey, $_POST['p']), '', ' class="' . $menuKey . '"'); ?><?php echo htmlspecialchars($page['name'], ENT_COMPAT, CHARSET, FALSE); ?></label></dd>
 <?php } ?>
     </dl>
 <?php } ?>

--- a/admin/profiles.php
+++ b/admin/profiles.php
@@ -161,8 +161,8 @@ require('includes/admin_html_head.php');
           </form>
         </td>
 <?php } else { ?>
-        <td class="name"><?php echo zen_output_string($profileDetails['name'], FALSE, TRUE); ?></td>
-        <td class="users"><?php echo zen_output_string($profileDetails['users'], FALSE, TRUE) ?></td>
+        <td class="name"><?php echo htmlspecialchars($profileDetails['name'], ENT_COMPAT, CHARSET, FALSE); ?></td>
+        <td class="users"><?php echo htmlspecialchars($profileDetails['users'], ENT_COMPAT, CHARSET, FALSE) ?></td>
 <?php if ($profileDetails['id'] != SUPERUSER_PROFILE) { ?>
         <td class="actions">
 <?php if ($action != 'delete') {  ?>
@@ -216,7 +216,7 @@ if ($action == 'delete' && $profileDetails['name'] == zen_get_profile_name($prof
         <input class="checkButton" type="button" value="<?php echo TEXT_UNCHECK_ALL; ?>" onclick="checkAll(this.form,'<?php echo $menuKey ?>',false);">
       </dt>
 <?php foreach ($pageList as $pageKey => $page) { ?>
-      <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), in_array($pageKey,$permittedPages), '', ' class="' . $menuKey . '"'); ?><?php echo zen_output_string($page['name'], false, true); ?></label></dd>
+      <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), in_array($pageKey,$permittedPages), '', ' class="' . $menuKey . '"'); ?><?php echo htmlspecialchars($page['name'], ENT_COMPAT, CHARSET, FALSE); ?></label></dd>
 <?php } ?>
     </dl>
 <?php } ?>
@@ -244,7 +244,7 @@ if ($action == 'delete' && $profileDetails['name'] == zen_get_profile_name($prof
         <input class="checkButton" type="button" value="<?php echo TEXT_UNCHECK_ALL; ?>" onclick="checkAll(this.form,'<?php echo $menuKey ?>',false);">
       </dt>
 <?php foreach ($pageList as $pageKey => $page) { ?>
-      <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), isset($_POST['p']) && in_array($pageKey, $_POST['p']), '', ' class="' . $menuKey . '"'); ?><?php echo zen_output_string($page['name'], false, true); ?></label></dd>
+      <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), isset($_POST['p']) && in_array($pageKey, $_POST['p']), '', ' class="' . $menuKey . '"'); ?><?php echo htmlspecialchars($page['name'], ENT_COMPAT, CHARSET, FALSE); ?></label></dd>
 <?php } ?>
     </dl>
 <?php } ?>

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -133,7 +133,7 @@ require('includes/admin_html_head.php');
       <tr>
         <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td class="main" valign="top"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo zen_draw_textarea_field('reviews_text', 'soft', '70', '15', htmlspecialchars(stripslashes($rInfo->reviews_text), ENT_COMPAT, CHARSET, TRUE), 'class="noEditor"'); ?></td>
+            <td class="main" valign="top"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo zen_draw_textarea_field('reviews_text', 'soft', '70', '15', zen_output_string_protected(stripslashes($rInfo->reviews_text)), 'class="noEditor"'); ?></td>
           </tr>
           <tr>
             <td class="smallText" align="right"><?php echo ENTRY_REVIEW_TEXT; ?></td>
@@ -190,7 +190,7 @@ require('includes/admin_html_head.php');
       <tr>
         <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td valign="top" class="main"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo nl2br(htmlspecialchars(zen_break_string($rInfo->reviews_text, 15), ENT_COMPAT, CHARSET, TRUE)); ?></td>
+            <td valign="top" class="main"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo nl2br(zen_output_string_protected(zen_break_string($rInfo->reviews_text, 15))); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -190,7 +190,7 @@ require('includes/admin_html_head.php');
       <tr>
         <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td valign="top" class="main"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo nl2br(zen_db_output(zen_break_string($rInfo->reviews_text, 15))); ?></td>
+            <td valign="top" class="main"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo nl2br(htmlspecialchars(zen_break_string($rInfo->reviews_text, 15), ENT_COMPAT, CHARSET, TRUE)); ?></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -273,7 +273,7 @@ function SetCategories() {
         <td><table border="0" cellspacing="0" cellpadding="2">
           <tr>
             <td class="main"><?php echo TEXT_SALEMAKER_NAME; ?>&nbsp;</td>
-            <td class="main"><?php echo zen_draw_input_field('name', htmlspecialchars($sInfo->sale_name, ENT_COMPAT, CHARSET, TRUE), 'size="37"'); ?></td>
+            <td class="main"><?php echo zen_draw_input_field('name', zen_output_string_protected($sInfo->sale_name), 'size="37"'); ?></td>
           </tr>
           <tr>
             <td class="main"><?php echo TEXT_SALEMAKER_DEDUCTION; ?>&nbsp;</td>
@@ -481,7 +481,7 @@ document.write('<?php echo '<a href="javascript:popupWindow(\\\'' . zen_href_lin
 
       $contents = array('form' => zen_draw_form('sales', FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $sInfo->sale_id . '&action=copyconfirm'));
       $contents[] = array('text' => sprintf(TEXT_INFO_COPY_INTRO, $sInfo->sale_name));
-      $contents[] = array('text' => '<br>&nbsp;' . zen_draw_input_field('newname', htmlspecialchars($sInfo->sale_name . '_', ENT_COMPAT, CHARSET, TRUE), 'size="31"'));
+      $contents[] = array('text' => '<br>&nbsp;' . zen_draw_input_field('newname', zen_output_string_protected($sInfo->sale_name . '_'), 'size="31"'));
       $contents[] = array('align' => 'center', 'text' => '<br>' . zen_image_submit('button_copy.gif', IMAGE_COPY) . '&nbsp;<a href="' . zen_href_link(FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $sInfo->sale_id) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a>');
       break;
     case 'delete':

--- a/admin/server_info.php
+++ b/admin/server_info.php
@@ -72,8 +72,8 @@ require('includes/admin_html_head.php');
     <strong><?php echo TITLE_DATABASE_DATE; ?></strong> <?php echo $system['db_date']; ?><br>
     <strong><?php echo TITLE_DATABASE_DATA_SIZE; ?></strong> <?php echo number_format(($system['database_size']/1024),0); ?> kB<br>
     <strong><?php echo TITLE_DATABASE_INDEX_SIZE; ?></strong> <?php echo number_format(($system['index_size']/1024),0); ?> kB<br>
-    <strong><?php echo TITLE_DATABASE_MYSQL_SLOW_LOG_STATUS; ?></strong> <?php echo $system['mysql_slow_query_log_status'] != '0' ? 'On' : 'Off'; ?><br><strong><?php echo TITLE_DATABASE_MYSQL_SLOW_LOG_FILE; ?></strong> <?php echo zen_output_string_protected($system['mysql_slow_query_log_file']); ?><br>
-    <strong><?php echo TITLE_DATABASE_MYSQL_MODE; ?></strong> <?php echo zen_output_string_protected(str_replace(',', ', ', $system['mysql_mode'])); ?></td>
+    <strong><?php echo TITLE_DATABASE_MYSQL_SLOW_LOG_STATUS; ?></strong> <?php echo $system['mysql_slow_query_log_status'] != '0' ? 'On' : 'Off'; ?><br><strong><?php echo TITLE_DATABASE_MYSQL_SLOW_LOG_FILE; ?></strong> <?php echo htmlspecialchars($system['mysql_slow_query_log_file'], ENT_COMPAT, CHARSET, FALSE); ?><br>
+    <strong><?php echo TITLE_DATABASE_MYSQL_MODE; ?></strong> <?php echo htmlspecialchars(str_replace(',', ', ', $system['mysql_mode']), ENT_COMPAT, CHARSET, FALSE); ?></td>
   </tr>
 </table>
 <br />

--- a/admin/whos_online.php
+++ b/admin/whos_online.php
@@ -399,22 +399,22 @@ require('includes/admin_html_head.php');
       }
     } else {
       if ($is_a_bot==true) {
-        echo '              <tr class="dataTableRowBot" onmouseout="this.className=\'dataTableRowBot\'" onclick="document.location.href=\'' . zen_href_link(FILENAME_WHOS_ONLINE, zen_get_all_get_params(array('info', 'action')) . 'info=' . zen_output_string_protected($whos_online->fields['session_id']), 'NONSSL') . '\'">' . "\n";
+        echo '              <tr class="dataTableRowBot" onmouseout="this.className=\'dataTableRowBot\'" onclick="document.location.href=\'' . zen_href_link(FILENAME_WHOS_ONLINE, zen_get_all_get_params(array('info', 'action')) . 'info=' . htmlspecialchars($whos_online->fields['session_id'], ENT_COMPAT, CHARSET, FALSE), 'NONSSL') . '\'">' . "\n";
       } else {
-        echo '              <tr class="dataTableRowWhois" onmouseout="this.className=\'dataTableRowWhois\'" onclick="document.location.href=\'' . zen_href_link(FILENAME_WHOS_ONLINE, zen_get_all_get_params(array('info', 'action')) . 'info=' . zen_output_string_protected($whos_online->fields['session_id']), 'NONSSL') . '\'">' . "\n";
+        echo '              <tr class="dataTableRowWhois" onmouseout="this.className=\'dataTableRowWhois\'" onclick="document.location.href=\'' . zen_href_link(FILENAME_WHOS_ONLINE, zen_get_all_get_params(array('info', 'action')) . 'info=' . htmlspecialchars($whos_online->fields['session_id'], ENT_COMPAT, CHARSET, FALSE), 'NONSSL') . '\'">' . "\n";
       }
   }
 ?>
                 <td class="dataTableContentWhois" colspan=3 valign="top">&nbsp;&nbsp;<?php echo TIME_PASSED_LAST_CLICKED . '<br />&nbsp;&nbsp;&nbsp;&nbsp;' . zen_check_minutes($whos_online->fields['time_last_click']); ?> ago</td>
                 <td class="dataTableContentWhois" colspan=5 valign="top">
                   <?php
-                    echo TEXT_SESSION_ID . zen_output_string_protected($whos_online->fields['session_id']) . '<br />' .
-                    TEXT_HOST . zen_output_string_protected($whos_online->fields['host_address']) . '<br />' .
-                    TEXT_USER_AGENT . zen_output_string_protected($whos_online->fields['user_agent']) . '<br />';
+                    echo TEXT_SESSION_ID . htmlspecialchars($whos_online->fields['session_id'], ENT_COMPAT, CHARSET, FALSE) . '<br />' .
+                    TEXT_HOST . htmlspecialchars($whos_online->fields['host_address'], ENT_COMPAT, CHARSET, FALSE) . '<br />' .
+                    TEXT_USER_AGENT . htmlspecialchars($whos_online->fields['user_agent'], ENT_COMPAT, CHARSET, FALSE) . '<br />';
 
-                    $lastURLlink = '<a href="' . zen_output_string_protected($whos_online->fields['last_page_url']) . '" target="_blank">' . '<u>' . zen_output_string_protected($whos_online->fields['last_page_url']) . '</u>' . '</a>';
+                    $lastURLlink = '<a href="' . htmlspecialchars($whos_online->fields['last_page_url'], ENT_COMPAT, CHARSET, FALSE) . '" target="_blank">' . '<u>' . htmlspecialchars($whos_online->fields['last_page_url'], ENT_COMPAT, CHARSET, FALSE) . '</u>' . '</a>';
                     if (preg_match('/^(.*)' . zen_session_name() . '=[a-f,0-9]+[&]*(.*)/i', $whos_online->fields['last_page_url'], $array)) {
-                      $lastURLlink = zen_output_string_protected($array[1] . $array[2]);
+                      $lastURLlink = htmlspecialchars($array[1] . $array[2], ENT_COMPAT, CHARSET, FALSE);
                     }
                     echo '<div class="last-url-link">' . $lastURLlink . '</div>';
                   ?>

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1054,8 +1054,8 @@ class order extends base {
     //comments area
       $html_msg['ORDER_COMMENTS'] = '';
       if ($this->info['comments']) {
-        $email_order .= zen_db_output($this->info['comments']) . "\n\n";
-        $html_msg['ORDER_COMMENTS'] = nl2br(zen_db_output($this->info['comments']));
+        $email_order .= zen_output_string_protected($this->info['comments']) . "\n\n";
+        $html_msg['ORDER_COMMENTS'] = nl2br(zen_output_string_protected($this->info['comments']));
       }
 
     //products area

--- a/includes/functions/compatibility.php
+++ b/includes/functions/compatibility.php
@@ -11,3 +11,13 @@
 
 
 // This file is empty in v1.5.2
+
+/**
+ * Function performed same action as zen_output_string_protected therefore is being deprecated.
+ * @param $string - string to sanitize
+ * @return string
+ */
+function zen_db_output($string)
+{
+    return zen_output_string_protected($string);
+}

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -1009,11 +1009,8 @@ if (!defined('IS_ADMIN_FLAG')) {
     return $db->Execute($query);
   }
 
-////
-  function zen_db_output($string) {
-    return htmlspecialchars($string);
-  }
-
+/* function zen_db_output has been deprecated in place of zen_output_string_protected and can be found in the store's
+includes/functions/compatibility.php file */
 
 // function to return field type
 // uses $tbl = table name, $fld = field name


### PR DESCRIPTION
Associated with issue #270 to remove all uses of zen_db_output, and replace with zen_output_string_protected, then to also address usage of htmlspecialchars where it were to output as a protected string and change that to use the zen_output_string_protected function.

Also as a separate commit, modified affected files to use the new database accessor (Issue #406) and also one for moving html code outside of php calls..