### PR TITLE
Add error reporting to zc_install for problems writing configure.php files

### DIFF
--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -138,6 +138,10 @@ define('TEXT_NAVBAR_ADMIN_SETUP', 'Admin Setup');
 define('TEXT_NAVBAR_COMPLETION', 'Finished');
 define('TEXT_NAVBAR_PAYMENT_PROVIDERS', 'Payment Providers');
 
+define('TEXT_ERROR_PROBLEMS_WRITING_CONFIGUREPHP_FILES', 'There were problems preparing and storing the configure.php files. YOUR INSTALL DID NOT COMPLETE PROPERLY.<br>Additional technical details may be found in your /logs/ folder.');
+define('TEXT_ERROR_COULD_NOT_READ_CFGFILE_TEMPLATE', 'Could not read the master config file layout: %s. Please ensure the file exists and is readable.');
+define('TEXT_ERROR_COULD_NOT_WRITE_CONFIGFILE', 'Could not write the generated config file: %s. Please ensure the file exists and is writable.');
+
 define('TEXT_ERROR_STORE_CONFIGURE', "Main /includes/configure.php file does not exist (isn't readable) or is not writeable");
 define('TEXT_ERROR_ADMIN_CONFIGURE', "Admin /admin/includes/configure.php does not exist (isn't readable) or is not writeable");
 define('TEXT_ERROR_PHP_VERSION', str_replace(array("\n", "\r"), '', 'Incorrect PHP Version.

--- a/zc_install/includes/modules/pages/admin_setup/header_php.php
+++ b/zc_install/includes/modules/pages/admin_setup/header_php.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2018 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:  New in v1.5.5 $
  */
@@ -25,5 +25,6 @@
     $isUpgrade = FALSE;
     require (DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
     $result = new zcConfigureFileWriter($_POST);
-    //@TODO - error reporting?
+
+    $errors = $result->errors;
   }

--- a/zc_install/includes/template/templates/admin_setup_default.php
+++ b/zc_install/includes/template/templates/admin_setup_default.php
@@ -9,6 +9,17 @@
 
 <?php require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.php'); ?>
 
+<?php if (count($errors)) { ?>
+    <div class="alert-box alert">
+<?php
+      foreach ($errors as $errormessage) {
+        echo $errormessage . '<br>';
+      }
+      echo TEXT_ERROR_PROBLEMS_WRITING_CONFIGUREPHP_FILES;
+?>
+    </div>
+<?php } ?>
+
 <form id="admin_setup" name="admin_setup" method="post" action="index.php?main_page=completion" data-abide>
   <input type="hidden" name="action" value="process" >
   <input type="hidden" name="lng" value="<?php echo $lng; ?>" >


### PR DESCRIPTION
Add meaningful error messages on-screen if config files couldn't be written properly.