### PR TITLE
Set a default charset during zc_install, for use with creating new tables

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -32,7 +32,7 @@ class zcDatabaseInstaller
     $this->dbPassword = $options['db_password'];
     $this->dbName = $options['db_name'];
     $this->dbPrefix = $options['db_prefix'];
-    $this->dbCharset = $options['db_charset'];
+    $this->dbCharset = trim($options['db_charset']) == '' ? 'utf8' : $options['db_charset'];
     $this->dbType = in_array($options['db_type'], $dbtypes) ? $options['db_type'] : 'mysql';
     $this->dieOnErrors = isset($options['dieOnErrors']) ? (bool)$options['dieOnErrors'] : FALSE;
     $this->errors = array();


### PR DESCRIPTION
When zc_install creates new tables, it attempts to set a collation value, but fails if the `db_charset` is blank. This assumes a safe default.