### PR TITLE
Add CURL fallbacks to support hosting companies that can't do security right

### DIFF
--- a/extras/curltester.php
+++ b/extras/curltester.php
@@ -9,7 +9,7 @@
  * @package utilities
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Sat Jan 23 18:51:35 2016 +0000 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Wed Mar 16 16:12:21 2016 -0500 Modified in v1.5.5 $
  */
 // no caching
 header('Cache-Control: no-cache, no-store, must-revalidate');
@@ -67,6 +67,9 @@ doCurlTest('https://onlinetools.ups.com/ups.app/xml/Rate');
 echo 'Connecting to FedEx (port 80)...<br>';
 dofsockTest('fedex.com', 80);
 
+echo 'Connecting to Canada Post REST API (SSL) ...<br>';
+doCurlTest('https://ct.soa-gw.canadapost.ca/rs/ship/price');
+
 echo 'Connecting to PayPal IPN (port 443)...<br>';
 dofsockTest('www.paypal.com', 443);
 doCurlTest('https://www.paypal.com/cgi-bin/webscr');
@@ -88,11 +91,6 @@ doCurlTest('https://api-3t.paypal.com/nvp');
 
 echo 'Connecting to PayPal Express/Pro Sandbox ...<br>';
 doCurlTest('https://api-3t.sandbox.paypal.com/nvp');
-
-if (time() < mktime(0, 0, 0, 3, 1, 2016)) {
-  echo 'Connecting to PayPal SECURITY ENDPOINT 2016 Sandbox ...<br>';
-  doCurlTest('https://test-api-3t.sandbox.paypal.com/nvp');
-}
 
 echo 'Connecting to PayPal Payflowpro Server ...<br>';
 doCurlTest('https://payflowpro.paypal.com/transaction');
@@ -153,17 +151,29 @@ function doCurlTest($url = 'http://s3.amazonaws.com/zencart-curltest/endpoint', 
   curl_setopt($ch, CURLOPT_FRESH_CONNECT, TRUE);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
   curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
-  curl_setopt($ch, CURLOPT_USERAGENT, 'Zen Cart(tm) - CURL TEST');
+  curl_setopt($ch, CURLOPT_USERAGENT, 'Zen Cart(tm) - CURL TEST v155');
 
   if (isset($_GET['i'])) curl_setopt($ch, CURLOPT_CERTINFO, TRUE);
 
-//  curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+//  curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); // not directly implemented here, because it is more future-proof and therefore generally more secure to allow Curl to autonegotiate the best mutually-supported protocol, by not specifying CURLOPT_SSLVERSION at all.
+
 //  curl_setopt($ch, CURLOPT_CAINFO, '/local/path/to/cacert.pem'); // for offline testing, this file can be obtained from http://curl.haxx.se/docs/caextract.html ... should never be used in production!
 
 
   $result = curl_exec($ch);
   $errtext = curl_error($ch);
   $errnum = curl_errno($ch);
+  // check for curl TLS version problem, and resubmit  (common with outdated hosts like HostGator)
+  if (in_array($errnum, array(35))) {
+    echo $errorMessage . $errnum . ': ' . $errtext;
+    echo '<br><p style="color:red;"><strong>Error 35 often means that the TLS/SSL connection capabilities of your server are outdated and your server administrator is behind schedule applying security updates, thus preventing the ability to connect to 3rd-party services using more modern security for communications.</strong></p>';
+    echo 'Testing again with less security...<br>';
+    curl_setopt($ch, CURLOPT_SSLVERSION, 6); // Using the defined value of 6 instead of CURL_SSLVERSION_TLSv1_2 since these outdated hosts also don't properly implement this constant either.
+    $result = curl_exec($ch);
+    $errtext = curl_error($ch);
+    $errnum = curl_errno($ch);
+  }
+
   // check for common certificate errors, and resubmit
   if (in_array($errnum, array(60,61))) {
     echo $errorMessage . $errnum . ': ' . $errtext;

--- a/extras/paypal_tlstest.php
+++ b/extras/paypal_tlstest.php
@@ -2,14 +2,14 @@
 /**
  * Standalone TLS Test tool for PayPal connection readiness in 2016
  * per https://www.paypal-knowledge.com/infocenter/index?page=content&widgetview=true&id=FAQ1914&viewlocale=en_US
- * 
+ *
  * Accepted parameters:
  *   i=1 -- to show certificate details
  *
  * @package utilities
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Wed Dec 30 18:38:35 2015 -0500 New in v1.5.5 $
+ * @version $Id: Author: DrByte  Wed Mar 16 16:12:21 2016 -0500  New in v1.5.5 $
  */
 // don't show error messages to browser
 ini_set('display_errors', 0);
@@ -38,11 +38,21 @@ $result = curl_exec($ch);
 $errtext = curl_error($ch);
 $errnum = curl_errno($ch);
 $commInfo = @curl_getinfo($ch);
-curl_close ($ch);
 
 if (isset($commInfo['url'])) $commInfo['url'] = '"' . $commInfo['url'] . '"';
 
 // Handle results
+if ($errnum == 35) {
+  echo '<p style="color:red;font-weight: bold;">Error 35 - Your server does not yet support proper auto-negotiation of secure communications protocols. We will try again by downgrading the communications parameters. This means your server administrator still needs to apply some updates to make your server fully compatible with modern security standards.</p><br><br>';
+  echo 'Trying again with lesser security:<br><br>';
+  curl_setopt($ch, CURLOPT_SSLVERSION, 6); // Using the defined value of 6 instead of CURL_SSLVERSION_TLSv1_2 since these outdated hosts also don't properly implement this constant either.
+  $result = curl_exec($ch);
+  $errtext = curl_error($ch);
+  $errnum = curl_errno($ch);
+  $commInfo = @curl_getinfo($ch);
+}
+curl_close ($ch);
+
 if ($errnum != 0) {
   echo 'Error: ' . $errnum . ': ' . $errtext . '<br><br>';
 } else {

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Thu Mar 3 22:31:02 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Wed Mar 16 16:12:21 2016 -0500 Modified in v1.5.5 $
  */
 /**
  * Authorize.net Payment Module (AIM version)
@@ -653,18 +653,18 @@ class authorizenet_aim extends base {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_TIMEOUT, 15);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 15);
-//   curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // NOTE: Leave commented-out! or set to TRUE!  This should NEVER be set to FALSE in production!!!!
-//   curl_setopt($ch, CURLOPT_CAINFO, '/local/path/to/cacert.pem'); // for offline testing, this file can be obtained from http://curl.haxx.se/docs/caextract.html ... should never be used in production!
-    if (CURL_PROXY_REQUIRED == 'True') {
-      $this->proxy_tunnel_flag = (defined('CURL_PROXY_TUNNEL_FLAG') && strtoupper(CURL_PROXY_TUNNEL_FLAG) == 'FALSE') ? false : true;
-      curl_setopt ($ch, CURLOPT_HTTPPROXYTUNNEL, $this->proxy_tunnel_flag);
-      curl_setopt ($ch, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-      curl_setopt ($ch, CURLOPT_PROXY, CURL_PROXY_SERVER_DETAILS);
-    }
 
     $this->authorize = curl_exec($ch);
     $this->commError = curl_error($ch);
     $this->commErrNo = curl_errno($ch);
+
+    if ($this->commErrNo == 35) {
+      trigger_error('ALERT: Could not process Authorize.net AIM transaction via normal CURL communications. Your server is encountering connection problems using TLS 1.2 ... because your hosting company cannot autonegotiate a secure protocol with modern security protocols. We will try the transaction again, but this is resulting in a very long delay for your customers, and could result in them attempting duplicate purchases. Get your hosting company to update their TLS capabilities ASAP.', E_USER_NOTICE);
+      curl_setopt($ch, CURLOPT_SSLVERSION, 6); // Using the defined value of 6 instead of CURL_SSLVERSION_TLSv1_2 since these outdated hosts also don't properly implement this constant either.
+      $this->authorize = curl_exec($ch);
+      $this->commError = curl_error($ch);
+      $this->commErrNo = curl_errno($ch);
+    }
 
     $this->commInfo = @curl_getinfo($ch);
     curl_close ($ch);

--- a/includes/modules/payment/authorizenet_echeck.php
+++ b/includes/modules/payment/authorizenet_echeck.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Thu Aug 7 23:50:02 2014 -0300 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Wed Mar 16 16:12:21 2016 -0500 Modified in v1.5.5 $
  */
 /**
  * Authorize.net echeck Payment Module
@@ -589,18 +589,18 @@ class authorizenet_echeck extends base {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_TIMEOUT, 15);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 15);
-//   curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // NOTE: Leave commented-out! or set to TRUE!  This should NEVER be set to FALSE in production!!!!
-//   curl_setopt($ch, CURLOPT_CAINFO, '/local/path/to/cacert.pem'); // for offline testing, this file can be obtained from http://curl.haxx.se/docs/caextract.html ... should never be used in production!
-    if (CURL_PROXY_REQUIRED == 'True') {
-      $this->proxy_tunnel_flag = (defined('CURL_PROXY_TUNNEL_FLAG') && strtoupper(CURL_PROXY_TUNNEL_FLAG) == 'FALSE') ? false : true;
-      curl_setopt ($ch, CURLOPT_HTTPPROXYTUNNEL, $this->proxy_tunnel_flag);
-      curl_setopt ($ch, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-      curl_setopt ($ch, CURLOPT_PROXY, CURL_PROXY_SERVER_DETAILS);
-    }
 
     $this->authorize = curl_exec($ch);
     $this->commError = curl_error($ch);
     $this->commErrNo = curl_errno($ch);
+
+    if ($this->commErrNo == 35) {
+      trigger_error('ALERT: Could not process Authorize.net echeck transaction via normal CURL communications. Your server is encountering connection problems using TLS 1.2 ... because your hosting company cannot autonegotiate a secure protocol with modern security protocols. We will try the transaction again, but this is resulting in a very long delay for your customers, and could result in them attempting duplicate purchases. Get your hosting company to update their TLS capabilities ASAP.', E_USER_NOTICE);
+      curl_setopt($ch, CURLOPT_SSLVERSION, 6); // Using the defined value of 6 instead of CURL_SSLVERSION_TLSv1_2 since these outdated hosts also don't properly implement this constant either.
+      $this->authorize = curl_exec($ch);
+      $this->commError = curl_error($ch);
+      $this->commErrNo = curl_errno($ch);
+    }
 
     $this->commInfo = @curl_getinfo($ch);
     curl_close ($ch);

--- a/includes/modules/payment/paypal/paypal_curl.php
+++ b/includes/modules/payment/paypal/paypal_curl.php
@@ -5,7 +5,7 @@
  * @package paymentMethod
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Sun Oct 18 01:51:14 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Wed Mar 16 16:12:21 2016 -0500 Modified in v1.5.5 $
  */
 
 /**
@@ -451,6 +451,14 @@ class paypal_curl extends base {
     $response = curl_exec($ch);
     $commError = curl_error($ch);
     $commErrNo = curl_errno($ch);
+
+    if ($commErrNo == 35) {
+      trigger_error('ALERT: Could not process PayPal transaction via normal CURL communications. Your server is encountering connection problems using TLS 1.2 ... because your hosting company cannot autonegotiate a secure protocol with modern security protocols. We will try the transaction again, but this is resulting in a very long delay for your customers, and could result in them attempting duplicate purchases. Get your hosting company to update their TLS capabilities ASAP.', E_USER_NOTICE);
+      curl_setopt($ch, CURLOPT_SSLVERSION, 6); // Using the defined value of 6 instead of CURL_SSLVERSION_TLSv1_2 since these outdated hosts also don't properly implement this constant either.
+      $response = curl_exec($ch);
+      $commError = curl_error($ch);
+      $commErrNo = curl_errno($ch);
+    }
 
     $commInfo = @curl_getinfo($ch);
     curl_close($ch);

--- a/includes/modules/payment/paypal/paypal_functions.php
+++ b/includes/modules/payment/paypal/paypal_functions.php
@@ -7,7 +7,7 @@
  * @copyright Portions Copyright 2003 osCommerce
  * @copyright Portions Copyright 2004 DevosC.com
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Thu Feb 4 21:02:58 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Wed Mar 16 16:12:21 2016 -0500 Modified in v1.5.5 $
  */
 
 // Functions for paypal processing
@@ -575,6 +575,12 @@
     $response = curl_exec($ch);
     $commError = curl_error($ch);
     $commErrNo = curl_errno($ch);
+    if ($commErrNo == 35) {
+      curl_setopt($ch, CURLOPT_SSLVERSION, 6);
+      $response = curl_exec($ch);
+      $commError = curl_error($ch);
+      $commErrNo = curl_errno($ch);
+    }
     $commInfo = @curl_getinfo($ch);
     curl_close($ch);
 

--- a/includes/modules/payment/sagepay_zc/SagepayUtil.php
+++ b/includes/modules/payment/sagepay_zc/SagepayUtil.php
@@ -45,6 +45,11 @@ class SagepayUtil
 
         $rawresponse = curl_exec($curlSession);
 
+        if (curl_errno($curlSession) == 35) {
+          curl_setopt($curlSession, CURLOPT_SSL_CURLOPT_SSLVERSION, 6);
+          $rawresponse = curl_exec($curlSession);
+        }
+
         if (curl_getinfo($curlSession, CURLINFO_HTTP_CODE) !== 200) {
             $output['Status'] = "FAIL";
             $output['StatusDetails'] = "Server Response: " . curl_getinfo($curlSession, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Some hosts don't yet support proper auto negotiation for modern TLS protocols, so this allows a timeout and then tries again by specifying a hard-coded protocol after logging the problem in the myDebug-xxxxx.log logs.