### PR TITLE
missing new files in 1.5.5 documentation

### DIFF
--- a/docs/changed_files-v1-5-5.html
+++ b/docs/changed_files-v1-5-5.html
@@ -92,10 +92,16 @@ OSI Certified is a certification mark of the Open Source Initiative.</p>
 <li>admin/includes/developers_tool_kit.css</li>
 <li>admin/includes/auto_loaders/currency_cron.core.php</li>
 <li>admin/includes/classes/AdminRequestSanitizer.php</li>
+<li>admin/includes/css/bootstrap.min.css</li>
+<li>admin/includes/css/font-awesome.min.css</li>
 <li>admin/includes/extra_datafiles/sagepay_transaction_database_tables.php</li>
+<li>admin/includes/fonts/ (whole folder)</li>
+<li>admin/includes/javascript/bootstrap.min.js</li>
+<li>admin/includes/javascript/jquery-1.12.1.min.js</li>
 <li>admin/includes/languages/english/ckeditor.php</li>
 <li>email/email_common.css</li>
 <li>extras/paypal_tlstest.php</li>
+<li>includes/defined_paths.php</li>
 <li>includes/auto_loaders/config.zca_layout.php</li>
 <li>includes/classes/Mobile_Detect.php</li>
 <li>includes/classes/categories_ul_generator.php</li>


### PR DESCRIPTION
I know the 1.5.5 version is live now, but while reading the readme for the changed files etc., I discovered these were missing from the list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/877)
<!-- Reviewable:end -->
