### PR TITLE
Fix bindvars to honor string entries that contain 'null'

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -4,7 +4,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Tue Mar 22 15:02:01 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: zcwilt  Fri Apr 15 Modified in v1.5.5 $
  */
 
   require('includes/application_top.php');
@@ -250,22 +250,22 @@
 
       if ($error == false) {
 
-        $sql_data_array = array('customers_firstname' => $customers_firstname,
-                                'customers_lastname' => $customers_lastname,
-                                'customers_email_address' => $customers_email_address,
-                                'customers_telephone' => $customers_telephone,
-                                'customers_fax' => $customers_fax,
-                                'customers_group_pricing' => $customers_group_pricing,
-                                'customers_newsletter' => $customers_newsletter,
-                                'customers_email_format' => $customers_email_format,
-                                'customers_authorization' => $customers_authorization,
-                                'customers_referral' => $customers_referral
-                                );
+        $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$customers_firstname, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_lastname', 'value'=>$customers_lastname, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_email_address', 'value'=>$customers_email_address, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_telephone', 'value'=>$customers_telephone, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_fax', 'value'=>$customers_fax, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_group_pricing', 'value'=>$customers_group_pricing, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_newsletter', 'value'=>$customers_newsletter, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_email_format', 'value'=>$customers_email_format, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_authorization', 'value'=>$customers_authorization, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_referral', 'value'=>$customers_referral, 'type'=>'stringIgnoreNull'),
+        );
 
-        if (ACCOUNT_GENDER == 'true') $sql_data_array['customers_gender'] = $customers_gender;
-        if (ACCOUNT_DOB == 'true') $sql_data_array['customers_dob'] = ($customers_dob == '0001-01-01 00:00:00' ? '0001-01-01 00:00:00' : zen_date_raw($customers_dob));
+        if (ACCOUNT_GENDER == 'true') $sql_data_array[] = array('fieldName'=>'customers_gender', 'value'=>$customers_gender, 'type'=>'stringIgnoreNull');
+        if (ACCOUNT_DOB == 'true')  $sql_data_array[] = array('fieldName'=>'customers_dob', 'value'=>($customers_dob == '0001-01-01 00:00:00' ? '0001-01-01 00:00:00' : zen_date_raw($customers_dob)), 'type'=>'date');
 
-        zen_db_perform(TABLE_CUSTOMERS, $sql_data_array, 'update', "customers_id = '" . (int)$customers_id . "'");
+        $db->perform(TABLE_CUSTOMERS, $sql_data_array, 'update', "customers_id = '" . (int)$customers_id . "'");
 
         $db->Execute("update " . TABLE_CUSTOMERS_INFO . "
                       set customers_info_date_account_last_modified = now()
@@ -273,27 +273,28 @@
 
         if ($entry_zone_id > 0) $entry_state = '';
 
-        $sql_data_array = array('entry_firstname' => $customers_firstname,
-                                'entry_lastname' => $customers_lastname,
-                                'entry_street_address' => $entry_street_address,
-                                'entry_postcode' => $entry_postcode,
-                                'entry_city' => $entry_city,
-                                'entry_country_id' => $entry_country_id);
+        $sql_data_array = array(array('fieldName'=>'entry_firstname', 'value'=>$customers_firstname, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'entry_lastname', 'value'=>$customers_lastname, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'entry_street_address', 'value'=>$entry_street_address, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'entry_postcode', 'value'=>$customers_telephone, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'entry_city', 'value'=>$entry_postcode, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'entry_country_id', 'value'=>$entry_country_id, 'type'=>'integer'),
+        );
 
         if (ACCOUNT_COMPANY == 'true') $sql_data_array['entry_company'] = $entry_company;
         if (ACCOUNT_SUBURB == 'true') $sql_data_array['entry_suburb'] = $entry_suburb;
 
         if (ACCOUNT_STATE == 'true') {
           if ($entry_zone_id > 0) {
-            $sql_data_array['entry_zone_id'] = $entry_zone_id;
-            $sql_data_array['entry_state'] = '';
+            $sql_data_array[] = array('fieldName'=>'entry_zone_id', 'value'=>$entry_zone_id, 'type'=>'integer');
+            $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>'', 'type'=>'stringIgnoreNull');
           } else {
-            $sql_data_array['entry_zone_id'] = '0';
-            $sql_data_array['entry_state'] = $entry_state;
+            $sql_data_array[] = array('fieldName'=>'entry_zone_id', 'value'=>0, 'type'=>'integer');
+            $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>$entry_state, 'type'=>'stringIgnoreNull');
           }
         }
 
-        zen_db_perform(TABLE_ADDRESS_BOOK, $sql_data_array, 'update', "customers_id = '" . (int)$customers_id . "' and address_book_id = '" . (int)$default_address_id . "'");
+        $db->perform(TABLE_ADDRESS_BOOK, $sql_data_array, 'update', "customers_id = '" . (int)$customers_id . "' and address_book_id = '" . (int)$default_address_id . "'");
         zen_record_admin_activity('Customer record updated for customer ID ' . (int)$customers_id, 'notice');
         zen_redirect(zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(array('cID', 'action')) . 'cID=' . $customers_id, 'NONSSL'));
 

--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -8,7 +8,7 @@
  * @copyright Portions Copyright 2003 osCommerce
  * @copyright Portions adapted from http://www.data-diggers.com/
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Sun Feb 14 17:28:50 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: zcwuilt Fri Apr 15 Modified in v1.5.5 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -441,11 +441,11 @@ class queryFactory extends base {
       break;
       case 'string':
         if (preg_match('/null/i', $value)) return 'null';
-        if (isset($typeArray[1])) {
-          $regexp = $typeArray[1];
-        }
         return '\'' . $this->prepare_input($value) . '\'';
       break;
+      case 'stringIgnoreNull':
+        return '\'' . $this->prepare_input($value) . '\'';
+        break;
       case 'noquotestring':
         return $this->prepare_input($value);
       break;

--- a/includes/modules/create_account.php
+++ b/includes/modules/create_account.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Fri Jan 1 12:23:19 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: zcwilt Fri Apr 15  Modified in v1.5.5 $
  */
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_MODULE_START_CREATE_ACCOUNT');
@@ -263,51 +263,54 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
     $messageStack->add_session('header', (defined('ERROR_CREATE_ACCOUNT_SPAM_DETECTED') ? ERROR_CREATE_ACCOUNT_SPAM_DETECTED : 'Thank you, your account request has been submitted for review.'), 'success');
     zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
   } else {
-    $sql_data_array = array('customers_firstname' => $firstname,
-                            'customers_lastname' => $lastname,
-                            'customers_email_address' => $email_address,
-                            'customers_nick' => $nick,
-                            'customers_telephone' => $telephone,
-                            'customers_fax' => $fax,
-                            'customers_newsletter' => (int)$newsletter,
-                            'customers_email_format' => $email_format,
-                            'customers_default_address_id' => 0,
-                            'customers_password' => zen_encrypt_password($password),
-                            'customers_authorization' => (int)$customers_authorization
+    $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_lastname', 'value'=>$lastname, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_email_address', 'value'=>$street_address, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_nick', 'value'=>$nick, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_telephone', 'value'=>$telephone, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_fax', 'value'=>$fax, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_newsletter', 'value'=>$newsletter, 'type'=>'integer'),
+                           array('fieldName'=>'customers_email_format', 'value'=>$email_format, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_default_address_id', 'value'=>0, 'type'=>'integer'),
+                           array('fieldName'=>'customers_password', 'value'=>zen_encrypt_password($password), 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'customers_authorization', 'value'=>$customers_authorization, 'type'=>'integer'),
     );
 
-    if ((CUSTOMERS_REFERRAL_STATUS == '2' and $customers_referral != '')) $sql_data_array['customers_referral'] = $customers_referral;
-    if (ACCOUNT_GENDER == 'true') $sql_data_array['customers_gender'] = $gender;
-    if (ACCOUNT_DOB == 'true') $sql_data_array['customers_dob'] = (empty($_POST['dob']) || $dob_entered == '0001-01-01 00:00:00' ? zen_db_prepare_input('0001-01-01 00:00:00') : zen_date_raw($_POST['dob']));
+    if ((CUSTOMERS_REFERRAL_STATUS == '2' and $customers_referral != '')) $sql_data_array[] = array('fieldName'=>'customers_referral', 'value'=>$customers_referral, 'type'=>'stringIgnoreNull');
+    if (ACCOUNT_GENDER == 'true') $sql_data_array[] = array('fieldName'=>'customers_referral', 'value'=>$gender, 'type'=>'stringIgnoreNull');
+    if (ACCOUNT_DOB == 'true')  $sql_data_array[] = array('fieldName'=>'customers_dob', 'value'=>empty($_POST['dob']) || $dob_entered == '0001-01-01 00:00:00' ? zen_db_prepare_input('0001-01-01 00:00:00') : zen_date_raw($_POST['dob']), 'type'=>'date');
 
-    zen_db_perform(TABLE_CUSTOMERS, $sql_data_array);
+    $db->perform(TABLE_CUSTOMERS, $sql_data_array);
 
     $_SESSION['customer_id'] = $db->Insert_ID();
 
     $zco_notifier->notify('NOTIFY_MODULE_CREATE_ACCOUNT_ADDED_CUSTOMER_RECORD', array_merge(array('customer_id' => $_SESSION['customer_id']), $sql_data_array));
 
-    $sql_data_array = array('customers_id' => $_SESSION['customer_id'],
-                            'entry_firstname' => $firstname,
-                            'entry_lastname' => $lastname,
-                            'entry_street_address' => $street_address,
-                            'entry_postcode' => $postcode,
-                            'entry_city' => $city,
-                            'entry_country_id' => $country);
 
-    if (ACCOUNT_GENDER == 'true') $sql_data_array['entry_gender'] = $gender;
-    if (ACCOUNT_COMPANY == 'true') $sql_data_array['entry_company'] = $company;
-    if (ACCOUNT_SUBURB == 'true') $sql_data_array['entry_suburb'] = $suburb;
+    $sql_data_array = array(array('fieldName'=>'customers_id', 'value'=>$_SESSION['customer_id'], 'type'=>'integer'),
+                            array('fieldName'=>'entry_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'entry_lastname', 'value'=>$lastname, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'entry_street_address', 'value'=>$street_address, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'entry_postcode', 'value'=>$postcode, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'entry_city', 'value'=>$city, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'entry_country_id', 'value'=>$country, 'type'=>'integer'),
+    );
+
+    if (ACCOUNT_GENDER == 'true') $sql_data_array[] = array('fieldName'=>'entry_gender', 'value'=>$gender, 'type'=>'stringIgnoreNull');
+    if (ACCOUNT_COMPANY == 'true') $sql_data_array[] = $sql_data_array[] = array('fieldName'=>'entry_company', 'value'=>$company, 'type'=>'stringIgnoreNull');
+    if (ACCOUNT_SUBURB == 'true') $sql_data_array[] = $sql_data_array[] = array('fieldName'=>'$suburb', 'value'=>$suburb, 'type'=>'stringIgnoreNull');
+
     if (ACCOUNT_STATE == 'true') {
       if ($zone_id > 0) {
-        $sql_data_array['entry_zone_id'] = $zone_id;
-        $sql_data_array['entry_state'] = '';
+        $sql_data_array[] = array('fieldName'=>'entry_zone_id', 'value'=>$zone_id, 'type'=>'integer');
+        $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>'', 'type'=>'stringIgnoreNull');
       } else {
-        $sql_data_array['entry_zone_id'] = '0';
-        $sql_data_array['entry_state'] = $state;
+        $sql_data_array[] = array('fieldName'=>'entry_zone_id', 'value'=>0, 'type'=>'integer');
+        $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>$state, 'type'=>'stringIgnoreNull');
       }
     }
 
-    zen_db_perform(TABLE_ADDRESS_BOOK, $sql_data_array);
+    $db->perform(TABLE_ADDRESS_BOOK, $sql_data_array);
 
     $address_id = $db->Insert_ID();
 

--- a/includes/modules/pages/account_edit/header_php.php
+++ b/includes/modules/pages/account_edit/header_php.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Fri Jan 1 12:23:19 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: zcwilt Fri Apr 15 Modified in v1.5.5 $
  */
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_EDIT');
@@ -101,19 +101,19 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
     $zco_notifier->notify('NOTIFY_NICK_UPDATE_EMAIL_ADDRESS', $nick, $db->prepareInput($email_address));
 
     // build array of data to store the requested changes
-    $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'string'),
-                            array('fieldName'=>'customers_lastname', 'value'=>$lastname, 'type'=>'string'),
-                            array('fieldName'=>'customers_email_address', 'value'=>$email_address, 'type'=>'string'),
-                            array('fieldName'=>'customers_telephone', 'value'=>$telephone, 'type'=>'string'),
-                            array('fieldName'=>'customers_fax', 'value'=>$fax, 'type'=>'string'),
-                            array('fieldName'=>'customers_email_format', 'value'=>$email_format, 'type'=>'string')
+    $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'customers_lastname', 'value'=>$lastname, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'customers_email_address', 'value'=>$email_address, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'customers_telephone', 'value'=>$telephone, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'customers_fax', 'value'=>$fax, 'type'=>'stringIgnoreNull'),
+                            array('fieldName'=>'customers_email_format', 'value'=>$email_format, 'type'=>'stringIgnoreNull')
     );
 
     if ((CUSTOMERS_REFERRAL_STATUS == '2' and $customers_referral != '')) {
-      $sql_data_array[] = array('fieldName'=>'customers_referral', 'value'=>$customers_referral, 'type'=>'string');
+      $sql_data_array[] = array('fieldName'=>'customers_referral', 'value'=>$customers_referral, 'type'=>'stringIgnoreNull');
     }
     if (ACCOUNT_GENDER == 'true') {
-      $sql_data_array[] = array('fieldName'=>'customers_gender', 'value'=>$gender, 'type'=>'string');
+      $sql_data_array[] = array('fieldName'=>'customers_gender', 'value'=>$gender, 'type'=>'stringIgnoreNull');
     }
     if (ACCOUNT_DOB == 'true') {
       if ($dob == '0001-01-01 00:00:00' or $_POST['dob'] == '') {
@@ -138,7 +138,7 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
     $where_clause = "customers_id = :customersID AND address_book_id = :customerDefaultAddressID";
     $where_clause = $db->bindVars($where_clause, ':customersID', $_SESSION['customer_id'], 'integer');
     $where_clause = $db->bindVars($where_clause, ':customerDefaultAddressID', $_SESSION['customer_default_address_id'], 'integer');
-    $sql_data_array = array(array('fieldName'=>'entry_firstname', 'value'=>$firstname, 'type'=>'string'),
+    $sql_data_array = array(array('fieldName'=>'entry_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),
     array('fieldName'=>'entry_lastname', 'value'=>$lastname, 'type'=>'string'));
 
     $db->perform(TABLE_ADDRESS_BOOK, $sql_data_array, 'update', $where_clause);

--- a/includes/modules/pages/address_book_process/header_php.php
+++ b/includes/modules/pages/address_book_process/header_php.php
@@ -6,7 +6,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Sun Oct 18 22:59:23 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Author: zcwilt Fri Apr 15 Modified in v1.5.5 $
  */
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ADDRESS_BOOK_PROCESS');
@@ -166,23 +166,23 @@ if (isset($_POST['action']) && (($_POST['action'] == 'process') || ($_POST['acti
   }
 
   if ($error == false) {
-    $sql_data_array= array(array('fieldName'=>'entry_firstname', 'value'=>$firstname, 'type'=>'string'),
-                           array('fieldName'=>'entry_lastname', 'value'=>$lastname, 'type'=>'string'),
-                           array('fieldName'=>'entry_street_address', 'value'=>$street_address, 'type'=>'string'),
-                           array('fieldName'=>'entry_postcode', 'value'=>$postcode, 'type'=>'string'),
-                           array('fieldName'=>'entry_city', 'value'=>$city, 'type'=>'string'),
+    $sql_data_array= array(array('fieldName'=>'entry_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'entry_lastname', 'value'=>$lastname, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'entry_street_address', 'value'=>$street_address, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'entry_postcode', 'value'=>$postcode, 'type'=>'stringIgnoreNull'),
+                           array('fieldName'=>'entry_city', 'value'=>$city, 'type'=>'stringIgnoreNull'),
                            array('fieldName'=>'entry_country_id', 'value'=>$country, 'type'=>'integer'));
 
     if (ACCOUNT_GENDER == 'true') $sql_data_array[] = array('fieldName'=>'entry_gender', 'value'=>$gender, 'type'=>'enum:m|f');
-    if (ACCOUNT_COMPANY == 'true') $sql_data_array[] = array('fieldName'=>'entry_company', 'value'=>$company, 'type'=>'string');
-    if (ACCOUNT_SUBURB == 'true') $sql_data_array[] = array('fieldName'=>'entry_suburb', 'value'=>$suburb, 'type'=>'string');
+    if (ACCOUNT_COMPANY == 'true') $sql_data_array[] = array('fieldName'=>'entry_company', 'value'=>$company, 'type'=>'stringIgnoreNull');
+    if (ACCOUNT_SUBURB == 'true') $sql_data_array[] = array('fieldName'=>'entry_suburb', 'value'=>$suburb, 'type'=>'stringIgnoreNull');
     if (ACCOUNT_STATE == 'true') {
       if ($zone_id > 0) {
         $sql_data_array[] = array('fieldName'=>'entry_zone_id', 'value'=>$zone_id, 'type'=>'integer');
-        $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>'', 'type'=>'string');
+        $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>'', 'type'=>'stringIgnoreNull');
       } else {
         $sql_data_array[] = array('fieldName'=>'entry_zone_id', 'value'=>'0', 'type'=>'integer');
-        $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>$state, 'type'=>'string');
+        $sql_data_array[] = array('fieldName'=>'entry_state', 'value'=>$state, 'type'=>'stringIgnoreNull');
       }
     }
 
@@ -202,8 +202,8 @@ if (isset($_POST['action']) && (($_POST['action'] == 'process') || ($_POST['acti
         $_SESSION['customer_zone_id'] = (($zone_id > 0) ? (int)$zone_id : '0');
         $_SESSION['customer_default_address_id'] = (int)$_GET['edit'];
 
-        $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'string'),
-                                array('fieldName'=>'customers_lastname', 'value'=>$lastname, 'type'=>'string'),
+        $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_lastname', 'value'=>$lastname, 'type'=>'stringIgnoreNull'),
                                 array('fieldName'=>'customers_default_address_id', 'value'=>$_GET['edit'], 'type'=>'integer'));
 
         if (ACCOUNT_GENDER == 'true') $sql_data_array[] = array('fieldName'=>'customers_gender', 'value'=>$gender, 'type'=>'enum:m|f');
@@ -230,10 +230,10 @@ if (isset($_POST['action']) && (($_POST['action'] == 'process') || ($_POST['acti
         //if (isset($_POST['primary']) && ($_POST['primary'] == 'on'))
         $_SESSION['customer_default_address_id'] = $new_address_book_id;
 
-        $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'string'),
-                                array('fieldName'=>'customers_lastname', 'value'=>$lastname, 'type'=>'string'));
+        $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),
+                                array('fieldName'=>'customers_lastname', 'value'=>$lastname, 'type'=>'stringIgnoreNull'));
 
-        if (ACCOUNT_GENDER == 'true') $sql_data_array[] = array('fieldName'=>'customers_gender', 'value'=>$gender, 'type'=>'string');
+        if (ACCOUNT_GENDER == 'true') $sql_data_array[] = array('fieldName'=>'customers_gender', 'value'=>$gender, 'type'=>'stringIgnoreNull');
         //if (isset($_POST['primary']) && ($_POST['primary'] == 'on'))
         $sql_data_array[] = array('fieldName'=>'customers_default_address_id', 'value'=>$new_address_book_id, 'type'=>'integer');
 


### PR DESCRIPTION
Because of the way bindvars worked some form entries would
assume that if the entry contained the string 'null' that the whole entry
should be set as a mysql null.
e.g. If your surname was NullSurname then the bindvars would insert a mysql Null
rather than the proper string