### PR TITLE
Is it corrct to have 2x $cheapest in the notifier?

### DIFF
--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -214,7 +214,7 @@ class shipping extends base {
           }
         }
       }
-      $this->notify('NOTIFY_SHIPPING_MODULE_CALCULATE_CHEAPEST', $cheapest, $cheapest, $rates);
+      $this->notify('NOTIFY_SHIPPING_MODULE_CALCULATE_CHEAPEST', $cheapest, $rates);
       return $cheapest;
     }
   }


### PR DESCRIPTION
Should
`$this->notify('NOTIFY_SHIPPING_MODULE_CALCULATE_CHEAPEST', $cheapest, $cheapest, $rates);`
be ??
`$this->notify('NOTIFY_SHIPPING_MODULE_CALCULATE_CHEAPEST', $cheapest, $rates);`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/900)
<!-- Reviewable:end -->
