### PR TITLE
Remove double-continue buttons on checkout-shipping-address screen

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_checkout_payment_address_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_checkout_payment_address_default.php
@@ -51,11 +51,11 @@
       require($template->get_template_dir('tpl_modules_checkout_address_book.php', DIR_WS_TEMPLATE, $current_page_base,'templates'). '/' . 'tpl_modules_checkout_address_book.php');
 ?>
 </fieldset>
+<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <?php
      }
 ?>
 
-<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
 </form>

--- a/includes/templates/responsive_classic/templates/tpl_checkout_shipping_address_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_checkout_shipping_address_default.php
@@ -53,13 +53,13 @@
       require($template->get_template_dir('tpl_modules_checkout_address_book.php', DIR_WS_TEMPLATE, $current_page_base,'templates'). '/' . 'tpl_modules_checkout_address_book.php');
 ?>
 </fieldset>
+<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <?php
      }
   }
 
 ?>
 
-<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
 </form>

--- a/includes/templates/template_default/templates/tpl_checkout_payment_address_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_address_default.php
@@ -50,11 +50,11 @@
       require($template->get_template_dir('tpl_modules_checkout_address_book.php', DIR_WS_TEMPLATE, $current_page_base,'templates'). '/' . 'tpl_modules_checkout_address_book.php');
 ?>
 </fieldset>
+<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <?php
      }
 ?>
 
-<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
 </form>

--- a/includes/templates/template_default/templates/tpl_checkout_shipping_address_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_shipping_address_default.php
@@ -53,13 +53,13 @@
       require($template->get_template_dir('tpl_modules_checkout_address_book.php', DIR_WS_TEMPLATE, $current_page_base,'templates'). '/' . 'tpl_modules_checkout_address_book.php');
 ?>
 </fieldset>
+<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <?php
      }
   }
 
 ?>
 
-<div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
 </form>


### PR DESCRIPTION
Also checkout-payment-address screen.

It was displaying 2 continue buttons if no "extra" addresses have been added to address-book.

(Continuation of commit https://github.com/zencart/zc-v1-series/commit/b151f45390c8bd0eb23eb41da3b12480cbe001da )