### PR TITLE
Fix extra breadcrumb that was appearing when always-open-with-category is enabled

### DIFF
--- a/includes/init_includes/init_category_path.php
+++ b/includes/init_includes/init_category_path.php
@@ -18,7 +18,7 @@ if (isset($_GET['cPath'])) {
 } elseif (isset($_GET['products_id']) && !zen_check_url_get_terms()) {
   $cPath = zen_get_product_path($_GET['products_id']);
 } else {
-  if (SHOW_CATEGORIES_ALWAYS == '1' && !zen_check_url_get_terms()) {
+  if ($current_page == 'index' && SHOW_CATEGORIES_ALWAYS == '1' && !zen_check_url_get_terms()) {
     $show_welcome = true;
     $cPath = (defined('CATEGORIES_START_MAIN') ? CATEGORIES_START_MAIN : '');
   } else {


### PR DESCRIPTION
Example case, according to @ajeh: 
1. Configure store to always-open-with-specific-category
2. Configure to always-show-that-category
3. Navigate to a non-prod-listing page, such as `main_page=featured_products` and see the extra breadcrumbs for the always-open-with category.

This PR fixes that.