### PR TITLE
Update BOC currency parsing to cope with their data changes

### DIFF
--- a/admin/includes/functions/localization.php
+++ b/admin/includes/functions/localization.php
@@ -4,7 +4,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Sat Oct 17 20:09:58 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  May 2 2016 Modified in v1.5.5a $
  */
 /**
  * Dependencies:
@@ -80,7 +80,7 @@ function quote_ecb_currency($currencyCode = '', $base = DEFAULT_CURRENCY)
   $url = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml';
   $data = '';
   if (!isset($XMLContent) || !is_array($XMLContent) || sizeof($XMLContent) < 1) {
-    $XMLContent = @file($url);
+    $XMLContent = file($url);
     if (! is_object($XMLContent) && function_exists('curl_init')) {
       // check via CURL instead.
       $XMLContent = doCurlCurrencyRequest('POST', $url, $data);
@@ -120,11 +120,15 @@ function quote_boc_currency($currencyCode = '', $base = DEFAULT_CURRENCY)
   }
   foreach ($CSVContent as $line) {
     if (substr($line, 0, 1) == '#' || substr($line, 0, 4) == 'Date' || trim($line) == '') continue;
-    $data = explode(',', $line);
-    $curName = $data[1];
-    $curRate = $data[sizeof($data)-1];
+    $data = explode(',', $line); // make an array, where each value is a separate column from the CSV
+    $curName = substr(trim($data[1]), 0, 3); // take only first 3 chars of currency code (ie: removes "_NOON" suffix, or whatever future suffix BOC adds)
+    $curRate = trim($data[sizeof($data)-1]);  // grab the value from the last column
     $currencyArray[trim($curName)] = (float)$curRate;
   }
+
+  if (!isset($currencyArray[$requested])) return false; // requested not found
+  if ($currencyArray[$requested] == 0) return false; // can't divide by zero
+
   $rate = (string)($currencyArray[DEFAULT_CURRENCY]/(float)$currencyArray[$requested]);
   return $rate;
 }

--- a/admin/includes/functions/localization.php
+++ b/admin/includes/functions/localization.php
@@ -123,10 +123,11 @@ function quote_boc_currency($currencyCode = '', $base = DEFAULT_CURRENCY)
     $data = explode(',', $line); // make an array, where each value is a separate column from the CSV
     $curName = substr(trim($data[1]), 0, 3); // take only first 3 chars of currency code (ie: removes "_NOON" suffix, or whatever future suffix BOC adds)
     $curRate = trim($data[sizeof($data)-1]);  // grab the value from the last column
-    $currencyArray[trim($curName)] = (float)$curRate;
+    // if the value isn't already set and isn't (basically) zero, update it in the array
+    if (!isset($currencyArray[trim($curName)]) || $currencyArray[trim($curName)] < 0.00001) $currencyArray[trim($curName)] = (float)$curRate;
   }
-
-  if (!isset($currencyArray[$requested])) return false; // requested not found
+  // sanity checks
+  if (!isset($currencyArray[$requested])) return false; // $requested not found
   if ($currencyArray[$requested] == 0) return false; // can't divide by zero
 
   $rate = (string)($currencyArray[DEFAULT_CURRENCY]/(float)$currencyArray[$requested]);


### PR DESCRIPTION
- BOC changed their currency codes to `XYZ_NOON` instead of just `XYZ`
- Also fixes a potential division-by-zero condition