### PR TITLE
Add legacy compatibility to adapt for new language-class components

### DIFF
--- a/includes/classes/language.php
+++ b/includes/classes/language.php
@@ -3,7 +3,7 @@
  * language Class.
  *
  * @package classes
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: language.php drbyte  Modified in v1.6.0 $
@@ -32,6 +32,11 @@ class language extends base {
   protected $language = '';
 
   /**
+   * @var array DEPRECATED - This is old, and only present for compatibility reasons. Use get_available_languages() instead.
+   */
+  public $catalog_languages = array();
+
+  /**
    * @param string $lng The language we'd like to set the site to, as long as it exists in the db
    * @return string
    */
@@ -56,6 +61,9 @@ class language extends base {
       // if none were found, there's gonna be trouble, but here we set a default, so we can avoid having to test for it later
       $this->available_languages['en'] = array('id' => 1, 'name' => 'english', 'image' => 'icon.gif', 'code' => 'en', 'directory' => 'english');
     }
+
+    // for legacy compatibility only:
+    $this->catalog_languages = $this->get_available_languages();
 
     return $this->set_language($lng);
   }

--- a/includes/init_includes/init_languages.php
+++ b/includes/init_includes/init_languages.php
@@ -4,7 +4,7 @@
  * see {@link  http://www.zen-cart.com/wiki/index.php/Developers_API_Tutorials#InitSystem wikitutorials} for more details.
  *
  * @package initSystem
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: init_languages.php 2753 2005-12-31 19:17:17Z wilt $
@@ -27,3 +27,7 @@ if (!isset($_SESSION['language']) || isset($_GET['language'])) {
   $_SESSION['languages_id'] = $val['id'];
   $_SESSION['languages_code'] = $val['code'];
 }
+if (!isset($lng) || (isset($lng) && !is_object($lng))) {
+  $lng = new language;
+}
+$language_list = $lng->get_available_languages();

--- a/includes/modules/sideboxes/languages.php
+++ b/includes/modules/sideboxes/languages.php
@@ -3,10 +3,10 @@
  * languages sidebox - allows customer to select from available languages installed on your site
  *
  * @package templateSystem
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: languages.php 2718 2005-12-28 06:42:39Z drbyte  Modified in v1.6.0 $
+ * @version $Id: languages.php  Modified in v1.6.0 $
  */
 
 // test if box should display
@@ -18,11 +18,6 @@ if (substr($current_page, 0, 8) != 'checkout') {
 }
 
 if ($show_languages == true) {
-  if (!isset($lng) || (isset($lng) && !is_object($lng))) {
-    $lng = new language;
-  }
-
-  $language_list = $lng->get_available_languages();
   require($template->get_template_dir('tpl_languages.php',DIR_WS_TEMPLATE, $current_page_base,'sideboxes'). '/tpl_languages.php');
   $title =  BOX_HEADING_LANGUAGES;
   $title_link = false;

--- a/includes/templates/template_default/common/html_header.php
+++ b/includes/templates/template_default/common/html_header.php
@@ -5,7 +5,7 @@
  * outputs the html header, eg the doctype and the entire [HEAD] section
  *
  * @package templateSystem
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:  Modified in v1.6.0 $
@@ -46,13 +46,11 @@ header('X-Frame-Options:SAMEORIGIN');
 
 <?php
   // BOF hreflang for multilingual sites
-  if (!isset($lng) || (isset($lng) && !is_object($lng))) {
-    $lng = new language;
-  }
-  reset($lng->catalog_languages);
-  while (list($key, $value) = each($lng->catalog_languages)) {
-    if ($value['id'] == $_SESSION['languages_id']) continue;
-    echo '<link rel="alternate" href="' . ($this_is_home_page ? zen_href_link(FILENAME_DEFAULT, 'language=' . $key, $request_type) : $canonicalLink . '&amp;language=' . $key) . '" hreflang="' . $key . '" />' . "\n";
+  if (isset($language_list) || $language_list = $lng->get_available_languages()) {
+    while (list($key, $value) = each($language_list)) {
+      if ($value['id'] == $_SESSION['languages_id']) continue;
+      echo '<link rel="alternate" href="' . ($this_is_home_page ? zen_href_link(FILENAME_DEFAULT, 'language=' . $key, $request_type) : $canonicalLink . '&amp;language=' . $key) . '" hreflang="' . $key . '" />' . "\n";
+    }
   }
   // EOF hreflang for multilingual sites
 ?>


### PR DESCRIPTION
This is only to attempt to avoid breaking very old plugins that haven't been upgraded to the newer more consistent syntax used in v160.