### PR TITLE
FIXES #923 Debug log on checkout

### DIFF
--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -233,6 +233,14 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
   $autoLoadConfig[180][] = array('autoType'=>'init_script',
                                  'loadFile'=> 'init_header.php');
 
+/**
+ * Breakpoint 185.
+ *
+ * require('includes/classes/class.phpmailer.php');
+ *
+ */
+  $autoLoadConfig[185][] = array('autoType'=>'class',
+                                 'loadFile'=> 'class.phpmailer.php');
 
 /**
  * NOTE: Most plugins should be added from point 200 onward.


### PR DESCRIPTION
To dup initial issue, start without this fix with a clean 160 db,
create an account and run an order.  Mailer fails to load and gives
an error log.