### PR TITLE
Fix strict sanitizer to use ignore group

### DIFF
--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -195,7 +195,8 @@ $group = array(
 );
 $sanitizer->addSimpleSanitization('ALPHANUM_DASH_UNDERSCORE', $group);
 
-$group = array('pages_title', 'page_params', 'music_genre_name', 'artists_name', 'record_company_name', 'countries_name', 'name', 'type_name', 'manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
+$group = array('pages_title', 'page_params', 'music_genre_name', 'artists_name', 'record_company_name', 'countries_name', 'name', 'type_name', 'manufacturers_name',
+               'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
                'tax_class_description', 'tax_class_title', 'tax_description', 'entry_company', 'customers_firstname',
                'customers_lastname', 'entry_street_address', 'entry_suburb', 'entry_city', 'entry_state', 'customers_referral',
                'symbol_left', 'symbol_right');

--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -195,7 +195,7 @@ $group = array(
 );
 $sanitizer->addSimpleSanitization('ALPHANUM_DASH_UNDERSCORE', $group);
 
-$group = array('music_genre_name', 'artists_name', 'record_company_name', 'countries_name', 'name', 'type_name', 'manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
+$group = array('page_params', 'music_genre_name', 'artists_name', 'record_company_name', 'countries_name', 'name', 'type_name', 'manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
                'tax_class_description', 'tax_class_title', 'tax_description', 'entry_company', 'customers_firstname',
                'customers_lastname', 'entry_street_address', 'entry_suburb', 'entry_city', 'entry_state', 'customers_referral',
                'symbol_left', 'symbol_right');

--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -5,7 +5,7 @@
  * @package initSystem
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: zcwilt Thu Apr 07 18:26:42 2016 +0000 Modified in v1.5.5 $
+ * @version $Id: Author: zcwilt Thu May 19 18:26:42 2016 +0000 Modified in v1.5.5 $
  */
 
 if (!defined('DO_STRICT_SANITIZATION')) {
@@ -196,7 +196,7 @@ $group = array(
 );
 $sanitizer->addSimpleSanitization('ALPHANUM_DASH_UNDERSCORE', $group);
 
-$group = array('title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
+$group = array('manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
                'tax_class_description', 'tax_class_title', 'tax_description', 'entry_company', 'customers_firstname',
                'customers_lastname', 'entry_street_address', 'entry_suburb', 'entry_city', 'entry_state', 'customers_referral',
                'symbol_left', 'symbol_right');

--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -182,7 +182,6 @@ $sanitizer->addSimpleSanitization('FILE_DIR_REGEX', $group);
 
 $group = array(
     'handler',
-    'type_name',
     'action',
     'product_attribute_is_free',
     'attributes_default',
@@ -196,7 +195,7 @@ $group = array(
 );
 $sanitizer->addSimpleSanitization('ALPHANUM_DASH_UNDERSCORE', $group);
 
-$group = array('manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
+$group = array('music_genre_name', 'artists_name', 'record_company_name', 'countries_name', 'name', 'type_name', 'manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
                'tax_class_description', 'tax_class_title', 'tax_description', 'entry_company', 'customers_firstname',
                'customers_lastname', 'entry_street_address', 'entry_suburb', 'entry_city', 'entry_state', 'customers_referral',
                'symbol_left', 'symbol_right');

--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -195,7 +195,7 @@ $group = array(
 );
 $sanitizer->addSimpleSanitization('ALPHANUM_DASH_UNDERSCORE', $group);
 
-$group = array('page_params', 'music_genre_name', 'artists_name', 'record_company_name', 'countries_name', 'name', 'type_name', 'manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
+$group = array('pages_title', 'page_params', 'music_genre_name', 'artists_name', 'record_company_name', 'countries_name', 'name', 'type_name', 'manufacturers_name', 'title', 'coupon_name', 'banners_title', 'coupon_code', 'group_name', 'geo_zone_name', 'geo_zone_description',
                'tax_class_description', 'tax_class_title', 'tax_description', 'entry_company', 'customers_firstname',
                'customers_lastname', 'entry_street_address', 'entry_suburb', 'entry_city', 'entry_state', 'customers_referral',
                'symbol_left', 'symbol_right');

--- a/not_for_release/testFramework/unittests/testAdminSanitizationCase.php
+++ b/not_for_release/testFramework/unittests/testAdminSanitizationCase.php
@@ -6,7 +6,7 @@
  * @package tests
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: Thu Apr 07 16:59:30 2016 +0000 New in v1.5.5 $
+ * @version $Id: Author: zcwilt Wed May 1116:59:30 2016 +0000 New in v1.5.5 $
  */
 
 /**
@@ -401,6 +401,11 @@ class testAdminSanitization extends PHPUnit_Framework_TestCase
     public function testStrictSanitizeValues()
     {
         $arq = new AdminRequestSanitizer;
+        $adminSanitizerTypes = array('STRICT_SANITIZE_VALUES' => array('type' => 'builtin'));
+        $arq->addSanitizerTypes($adminSanitizerTypes);
+        $group = array('some_param_ignore');
+        $arq->addSimpleSanitization('STRICT_SANITIZE_VALUES', $group);
+
         $_POST = array(
             'some_param_ignore' => '<strong>Name</strong>',
             'some_param_simple' => '100xyz_</script>();',
@@ -412,6 +417,7 @@ class testAdminSanitization extends PHPUnit_Framework_TestCase
         $arq->runSanitizers();
         $postAlreadySanitized = $arq->getPostKeysAlreadySanitized();
         $this->assertTrue(count($postAlreadySanitized) == 4);
+        $this->assertTrue($_POST['some_param_ignore'] == '<strong>Name</strong>');
         $this->assertTrue($_POST['some_param_simple'] == '100xyz_&lt;/script&gt;();');
         $this->assertTrue($_POST['some_param_array'][0] == '100xyz_&lt;/script&gt;();');
         $this->assertTrue($_POST['some_param_deep_array'][0][0] == '100xyz_&lt;/script&gt;();');

--- a/not_for_release/testFramework/unittests/testAdminSanitizationCase.php
+++ b/not_for_release/testFramework/unittests/testAdminSanitizationCase.php
@@ -6,7 +6,7 @@
  * @package tests
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: zcwilt Wed May 1116:59:30 2016 +0000 New in v1.5.5 $
+ * @version $Id: Author: zcwilt Wed May 11 16:59:30 2016 +0000 New in v1.5.5 $
  */
 
 /**


### PR DESCRIPTION
Fix strict sanitizer to use ignore group
Also add some fields that should allow entities such as & but were converting to `&amp;`