### PR TITLE
does not redirect on invalid product_id

### DIFF
--- a/includes/init_includes/init_sanitize.php
+++ b/includes/init_includes/init_sanitize.php
@@ -56,7 +56,7 @@ if (isset($_GET ['products_id']) && isset($_SESSION ['check_valid']) && $_SESSIO
      * do not recheck redirect
      */
     $_SESSION ['check_valid'] = 'false';
-    zen_redirect(zen_href_link($mainPage, 'products_id=' . $_GET ['products_id']));
+    //zen_redirect(zen_href_link($mainPage, 'products_id=' . $_GET ['products_id']));
   }
 } else {
   $_SESSION ['check_valid'] = 'true';


### PR DESCRIPTION
when an inactive/non-valid product link is clicked, ZC first issues an HTTP response of 302 and then a 404.  as the page no longer exists, there should NOT be a 302 issued prior to the 404.  the 404 gets handled from includes/modules/pages/product_info/header_php.php.  so i am unclear why a 302 is being issued here and then going to the same page.  

this PR removes the 302 response/redirect when an invalid product_id is selected.

https://www.zen-cart.com/showthread.php?220104&p=1311344#post1311344