### PR TITLE
Maintain order status that is above default on PayPal batch capture

### DIFF
--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -470,8 +470,8 @@ Processing...
       if ((int)$new_status == 0) $new_status = 1;
       if (in_array($_POST['payment_status'], array('Refunded', 'Reversed', 'Denied', 'Failed'))
            || substr($txn_type,0,8) == 'cleared-' || $txn_type=='echeck-cleared' || $txn_type == 'express-checkout-cleared') {
-        $sql = ("select orders_status from " . TABLE_ORDERS . "
-                 where orders_id = :ordersID:");
+        $sql = "select orders_status from " . TABLE_ORDERS . "
+                 where orders_id = :ordersID:";
         $sql = $db->bindVars($sql, ':ordersID:', $ordersID, 'integer');
         $old_status = $db->Execute($sql);
         if ($new_status < $oldstatus->fields['orders_status'] && (substr($txn_type, 0, 8) == 'cleared-' || $txn_type=='echeck-cleared' || $txn_type == 'express-checkout-cleared')) {

--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -466,11 +466,8 @@ Processing...
           break;
       }
       // update order status history with new information
-      ipn_debug_email('IPN NOTICE :: Set new status ' . $new_status . " for order ID = " .  $ordersID . ($_POST['pending_reason'] != '' ? '.   Reason_code = ' . $_POST['pending_reason'] : '') );
-      if ((int)$new_status == 0) {
-        $new_status = 1;
-        ipn_debug_email('IPN NOTICE :: Set new status ' . $new_status . " for order ID = " .  $ordersID . ($_POST['pending_reason'] != '' ? '.   Reason_code = ' . $_POST['pending_reason'] : '') );
-      }
+      if ((int)$new_status == 0) $new_status = 1;
+      
       if (in_array($_POST['payment_status'], array('Refunded', 'Reversed', 'Denied', 'Failed'))
            || substr($txn_type,0,8) == 'cleared-' || $txn_type=='echeck-cleared' || $txn_type == 'express-checkout-cleared') {
         $sql = "select orders_status from " . TABLE_ORDERS . "

--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -467,7 +467,10 @@ Processing...
       }
       // update order status history with new information
       ipn_debug_email('IPN NOTICE :: Set new status ' . $new_status . " for order ID = " .  $ordersID . ($_POST['pending_reason'] != '' ? '.   Reason_code = ' . $_POST['pending_reason'] : '') );
-      if ((int)$new_status == 0) $new_status = 1;
+      if ((int)$new_status == 0) {
+        $new_status = 1;
+        ipn_debug_email('IPN NOTICE :: Set new status ' . $new_status . " for order ID = " .  $ordersID . ($_POST['pending_reason'] != '' ? '.   Reason_code = ' . $_POST['pending_reason'] : '') );
+      }
       if (in_array($_POST['payment_status'], array('Refunded', 'Reversed', 'Denied', 'Failed'))
            || substr($txn_type,0,8) == 'cleared-' || $txn_type=='echeck-cleared' || $txn_type == 'express-checkout-cleared') {
         $sql = "select orders_status from " . TABLE_ORDERS . "
@@ -477,6 +480,7 @@ Processing...
         if ($new_status < $oldstatus->fields['orders_status'] && (substr($txn_type, 0, 8) == 'cleared-' || $txn_type=='echeck-cleared' || $txn_type == 'express-checkout-cleared')) {
           $new_status = $old_status->fields['orders_status'];
         }
+        ipn_debug_email('IPN NOTICE :: Set new status ' . $new_status . " for order ID = " .  $ordersID . ($_POST['pending_reason'] != '' ? '.   Reason_code = ' . $_POST['pending_reason'] : '') );
         ipn_update_orders_status_and_history($ordersID, $new_status, $txn_type);
         $zco_notifier->notify('NOTIFY_PAYPALIPN_STATUS_HISTORY_UPDATE', array($ordersID, $new_status, $txn_type));
       }

--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -470,6 +470,13 @@ Processing...
       if ((int)$new_status == 0) $new_status = 1;
       if (in_array($_POST['payment_status'], array('Refunded', 'Reversed', 'Denied', 'Failed'))
            || substr($txn_type,0,8) == 'cleared-' || $txn_type=='echeck-cleared' || $txn_type == 'express-checkout-cleared') {
+        $sql = ("select orders_status from " . TABLE_ORDERS . "
+                 where orders_id = :ordersID:");
+        $sql = $db->bindVars($sql, ':ordersID:', $ordersID, 'integer');
+        $old_status = $db->Execute($sql);
+        if ($new_status < $oldstatus->fields['orders_status'] && (substr($txn_type, 0, 8) == 'cleared-' || $txn_type=='echeck-cleared' || $txn_type == 'express-checkout-cleared')) {
+          $new_status = $old_status->fields['orders_status'];
+        }
         ipn_update_orders_status_and_history($ordersID, $new_status, $txn_type);
         $zco_notifier->notify('NOTIFY_PAYPALIPN_STATUS_HISTORY_UPDATE', array($ordersID, $new_status, $txn_type));
       }


### PR DESCRIPTION
Submitted to replace a previous pull request that doesn't want to play nice when rebasing from v155 to v160.

Discussion held back on ZC 1.5.1 at https://www.zen-cart.com/showthread.php?214423-Order-status-changes-after-batch-capture-on-PayPal-website where store owner observed that the status of orders that were previously manually updated inside of the ZC admin were lowered once batch capture was performed on PayPal site.

The change proposed above was reported as working at least before the and was added to the added if statement. And statement intent is to apply/allow the old status to remain if and only if the transaction is one that isn't intended to reduce the status. For example, refunding, reversing, denying or failing a transaction should not allow the status to remain elevated through this process, but instead take the status intended for those conditions.

